### PR TITLE
Clean up ansible: remove redundant playbooks and apt cache spam

### DIFF
--- a/ansible/roles/dns_server/tasks/main.yml
+++ b/ansible/roles/dns_server/tasks/main.yml
@@ -1,6 +1,7 @@
 - name: Install bind9
   ansible.builtin.apt:
-    update-cache: yes
+    update_cache: yes
+    cache_valid_time: 3600
     pkg:
       - bind9
       - rsync

--- a/ansible/roles/k8s/tasks/main.yml
+++ b/ansible/roles/k8s/tasks/main.yml
@@ -18,7 +18,8 @@
 
 - name: required packages
   ansible.builtin.apt:
-    update-cache: yes
+    update_cache: yes
+    cache_valid_time: 3600
     pkg:
       - apt-transport-https
       - ca-certificates
@@ -47,7 +48,7 @@
 
 - name: required k8s packages
   ansible.builtin.apt:
-    update-cache: yes
+    update_cache: yes
     pkg:
       - kubectl={{ k8s_aptversion }}
       - kubelet={{ k8s_aptversion }}

--- a/ansible/roles/linux_aptlike/tasks/main.yml
+++ b/ansible/roles/linux_aptlike/tasks/main.yml
@@ -1,6 +1,7 @@
 - name: Install things that make life tolerable
   ansible.builtin.apt:
-    update-cache: yes
+    update_cache: yes
+    cache_valid_time: 3600
     pkg:
       - vim
       - git

--- a/ansible/roles/nfs_client/tasks/main.yml
+++ b/ansible/roles/nfs_client/tasks/main.yml
@@ -1,6 +1,7 @@
 - name: Install required packages.
   ansible.builtin.apt:
-    update-cache: yes
+    update_cache: yes
+    cache_valid_time: 3600
     pkg:
       - nfs-common
 

--- a/ansible/roles/nomad/tasks/main.yml
+++ b/ansible/roles/nomad/tasks/main.yml
@@ -1,6 +1,7 @@
 - name: Install required packages.
   ansible.builtin.apt:
-    update-cache: yes
+    update_cache: yes
+    cache_valid_time: 3600
     pkg:
       - unzip
 

--- a/ansible/roles/ups/tasks/main.yml
+++ b/ansible/roles/ups/tasks/main.yml
@@ -1,6 +1,7 @@
 - name: Install nut
   ansible.builtin.apt:
-    update-cache: yes
+    update_cache: yes
+    cache_valid_time: 3600
     pkg:
       - nut
 

--- a/ansible/site-dns.yml
+++ b/ansible/site-dns.yml
@@ -1,7 +1,0 @@
-- name: dns servers
-  hosts: dns_server
-  become: true
-  become_user: root
-  roles:
-    - role: dns_server
-

--- a/ansible/site-nut.yml
+++ b/ansible/site-nut.yml
@@ -1,7 +1,0 @@
-- name: Connected UPS machines
-  hosts: ups
-  become: true
-  become_user: root
-  roles:
-    - role: ups
-

--- a/ansible/site-service_vip.yml
+++ b/ansible/site-service_vip.yml
@@ -1,6 +1,0 @@
-- name: service VIP
-  hosts: service_vip
-  become: true
-  become_user: root
-  roles:
-    - role: ansible-keepalived

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -37,3 +37,9 @@
   roles:
     - role: login
 
+- name: UPS machines
+  hosts: ups
+  become: true
+  become_user: root
+  roles:
+    - role: ups


### PR DESCRIPTION
- Delete site-dns.yml (already covered by site.yml), site-nut.yml and site-service_vip.yml (unused)
- Add ups play to site.yml so the ups group is actually managed
- Add cache_valid_time: 3600 to all apt calls in roles so apt-get update only runs once per play rather than once per role
- Also fix update-cache -> update_cache (underscore) for consistency