### PR TITLE
Add READMEs and inline comments throughout

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,46 @@
+# ansible
+
+Provisions and configures all hosts. Runs against hosts defined in `inventory.yml`.
+
+## Running
+
+```bash
+# All hosts
+bash apply_all.sh
+
+# Specific playbook / host subset
+ansible-playbook -i inventory.yml site.yml --limit hedwig
+```
+
+`CONSUL_GOSSIP_KEY` must be set in the environment before running — it's used to
+encrypt Consul cluster gossip traffic and must match across all nodes.
+
+## Host groups
+
+| Group | Hosts | Purpose |
+|---|---|---|
+| `nomadconsul` | picluster2/4/5, duckseason, hedwig, donkeh, bebop, rocksteady | Nomad clients+servers and Consul agents |
+| `nfs_server` | duckseason | Exports `/export/things` over NFS |
+| `dns_server` | hedwig, donkeh, duckseason | BIND9 with Consul forwarding for `.consul` queries |
+| `ups` | hedwig, duckseason | NUT for UPS monitoring |
+| `login` | rabbitseason | Public-facing SSH login node |
+
+`nomad_server: true` is set by default for nomadconsul hosts; set it explicitly to
+`false` on hosts that should run as clients only (see picluster5).
+
+## Roles
+
+| Role | Purpose |
+|---|---|
+| `nomad` | Installs Nomad binary, config, and systemd unit |
+| `consul` | Installs Consul binary, config, and systemd unit |
+| `docker` | Installs docker-ce + containerd (Nomad's container runtime) |
+| `nfs_client` | Mounts `/things` from duckseason |
+| `dns_server` | Configures BIND9 with Consul DNS forwarding |
+| `remove_k8s` | Strips Kubernetes packages and data dirs from a host being converted to Nomad |
+| `linux_aptlike` | Common baseline packages for apt-based hosts |
+| `login` | SSH hardening and user config for the login node |
+| `ups` | NUT client config for hosts with a locally attached UPS |
+| `publicsmtp` | Postfix + OpenDKIM for the public-facing mail relay |
+| `publicweb` | nginx config for static public web hosting |
+| `mailman` | Mailman3 mailing list config |

--- a/ansible/roles/consul/templates/consul.hcl.j2
+++ b/ansible/roles/consul/templates/consul.hcl.j2
@@ -1,10 +1,15 @@
 datacenter = "home"
 data_dir = "/opt/consul"
 encrypt = "{{ consul_gossip_key }}"
+# TLS verification disabled -- this is a trusted internal LAN and the gossip
+# encryption key (above) is sufficient. Enabling mTLS here would require
+# distributing certificates to every node.
 verify_incoming = false
 verify_outgoing = false
 verify_server_hostname = false
 acl = {
+  # ACL disabled; default_policy = "allow" means all agents can read/write.
+  # Acceptable for a homelab where all nodes are trusted.
   enabled = false
   default_policy = "allow"
   enable_token_persistence = true

--- a/ansible/roles/nomad/files/nomad.hcl
+++ b/ansible/roles/nomad/files/nomad.hcl
@@ -8,12 +8,16 @@ consul {
 }
 plugin "docker" {
   config {
+    # Required for jobs that need hardware device access (octoprint, z2m, CSI storage plugin).
     allow_privileged = true
     volumes {
-      enabled = true 
+      enabled = true
     }
   }
 }
+# raw_exec allows running commands directly on the host without a container.
+# Used by the letsencrypt-to-nomad-vars job and other infra tasks that need
+# host-level access.
 plugin "raw_exec" {
   config {
     enabled = true

--- a/cicd/README.md
+++ b/cicd/README.md
@@ -1,0 +1,10 @@
+# cicd
+
+CI/CD infrastructure configuration.
+
+| Directory | Contents |
+|---|---|
+| `web/` | HAProxy upstream config stubs for routing to CI and web services |
+
+The HAProxy configs here define upstream backends (e.g. Drone CI) that are
+included into the main HAProxy config on the reverse proxy host.

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,22 @@
+# monitoring
+
+Prometheus configuration files, bind-mounted into the prometheus container by
+the Nomad job in `nomad/monitoring/prometheus.hcl`.
+
+| File | Purpose |
+|---|---|
+| `prometheus.yml` | Main config: scrape jobs, alertmanager address, rule files |
+| `node_exporter_alerting_rules.yml` | Alerts for host-level metrics (disk, memory, load) |
+| `node_exporter_recording_rules.yml` | Pre-computed recording rules for dashboard performance |
+| `blackbox_alerting_rules.yml` | Alerts for failed HTTP/ICMP probes |
+| `prom-alertmanager.yml` | Alert routing and email notification config |
+| `prom-blackbox-exporter.yml` | Probe module definitions (http_2xx, icmp) |
+
+## Reloading config
+
+Prometheus and the blackbox exporter both support live config reload via HTTP:
+
+```bash
+bash reload_prometheus.sh
+bash reload_prometheus_blackbox.sh
+```

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -11,7 +11,11 @@ scrape_configs:
   - job_name: prometheus
     static_configs:
       - targets: ['localhost:9090']
+  # Static targets rather than Consul service discovery -- the cluster is small
+  # and fixed, so the complexity of SD isn't worth it.
   - job_name: node_exporter
+    # 1m interval rather than the global 15s -- node metrics don't need to be
+    # that fresh and this keeps cardinality down.
     scrape_interval: 1m
     scrape_timeout: 1m
     metrics_path: "/metrics"
@@ -58,6 +62,8 @@ scrape_configs:
     metrics_path: "/probe"
     params:
       module: [icmp]
+    # 1m for ICMP -- more frequent than this tends to cause alert flapping
+    # on transient packet loss.
     scrape_interval: 1m
     static_configs:
       - targets:

--- a/nomad/README.md
+++ b/nomad/README.md
@@ -1,0 +1,43 @@
+# nomad
+
+Nomad job definitions for everything running on the cluster.
+
+## Layout
+
+| Directory | Contents |
+|---|---|
+| `apps/` | User-facing applications |
+| `infra/` | Infrastructure services (databases, web, MQTT, DNS, certs, email) |
+| `monitoring/` | Prometheus, Grafana, Alertmanager, and exporters |
+| `storage/` | CSI plugin (NFS) and volume definitions |
+| `cron/` | Periodic batch jobs |
+| `acl/` | Nomad ACL policies |
+
+## Secrets
+
+Secrets are stored in Nomad variables and injected into jobs via `template` blocks:
+
+```hcl
+template {
+  data = <<EOH
+{{- with nomadVar "nomad/jobs/myjob" -}}
+MY_SECRET={{ .some_key }}
+{{- end -}}
+EOH
+  destination = "secrets/env"
+  env         = true
+}
+```
+
+Variables must be created manually before deploying a job that needs them:
+
+```bash
+nomad var put nomad/jobs/myjob some_key=value
+```
+
+The `nomad/jobs/<jobname>` path is the convention used throughout.
+
+## Datacenter
+
+All jobs target datacenter `"home"`. This matches the `datacenter = "home"` in
+the Consul and Nomad agent configs deployed by Ansible.

--- a/nomad/apps/README.md
+++ b/nomad/apps/README.md
@@ -1,0 +1,19 @@
+# nomad/apps
+
+User-facing applications.
+
+| Job | What it is | Notes |
+|---|---|---|
+| `hass` | Home Assistant | Pinned to `hedwig` (local SSD, Zigbee coordinator) |
+| `z2m` | Zigbee2MQTT | Pinned to `picluster5` (Conbee USB stick attached there) |
+| `octoprint` | 3D printer web UI + webcam streamer | Pinned to `picluster5` (printer USB attached there) |
+| `miniflux` | RSS reader | Backed by postgres |
+| `birdnet` | BirdNET-Pi bird call detection | Backed by CSI NFS volume |
+| `giv_tcp` | GivEnergy solar inverter monitoring | Talks to inverter at fixed LAN IP |
+| `cringesweeper` | Sweeps old posts from Bluesky and Mastodon | Secrets in `nomad/jobs/cringesweeper` |
+
+## Hardware-pinned jobs
+
+Several jobs are pinned to specific hosts via hostname constraints because they
+need access to locally attached USB devices. If a device moves to a different host,
+update the `constraint` block in the job file.

--- a/nomad/apps/hass/hass.hcl
+++ b/nomad/apps/hass/hass.hcl
@@ -25,6 +25,9 @@ job "hass" {
         ports = ["hass"]
       }
      env {
+       # Home Assistant installs user Python packages (HACS integrations etc.) into
+       # /config/deps, which is on the bind-mounted local SSD. This makes them
+       # persist across container restarts without modifying the image.
        PYTHONUSERBASE = "/config/deps"
        PYTHONPATH = "/config/deps/python3.8/site-packages"
      }

--- a/nomad/apps/octoprint/octoprint.hcl
+++ b/nomad/apps/octoprint/octoprint.hcl
@@ -18,6 +18,7 @@ job "octoprint" {
           group = "octoprint"
         } 
         ports = ["octoprint"]
+        # privileged is required for USB serial and video device access.
         privileged = true
         devices = [
          {
@@ -35,6 +36,9 @@ job "octoprint" {
       }
     }
     network {
+      # host networking is required alongside privileged mode for reliable USB
+      # device access. The container listens on port 80; static = "8888" exposes
+      # it on the host at 8888.
       mode = "host"
       port "octoprint" {
         static = "8888"

--- a/nomad/cron/README.md
+++ b/nomad/cron/README.md
@@ -1,0 +1,8 @@
+# nomad/cron
+
+Periodic batch jobs (Nomad `type = "batch"` with `periodic` blocks).
+
+| Job | What it does |
+|---|---|
+| `git-pull-homelab` | Pulls the latest homelab repo to a local path on the cluster |
+| `pull-gitrepo` | Generic git pull job, parameterised by repo |

--- a/nomad/infra/README.md
+++ b/nomad/infra/README.md
@@ -1,0 +1,30 @@
+# nomad/infra
+
+Infrastructure services that apps depend on.
+
+| Job | What it is | Notes |
+|---|---|---|
+| `postgres` | PostgreSQL database | Backed by CSI NFS volume |
+| `mysql` | MySQL database | Backed by CSI NFS volume |
+| `mosquitto` | MQTT broker | Used by Home Assistant, GivTCP, Z2M |
+| `web` | nginx reverse proxy | Terminates SSL, routes to Consul service names |
+| `certbot` | Let's Encrypt cert renewal | Pinned to `duckseason`; writes to local `/export/things/docker/ssl` |
+| `letsencrypt-to-nomad-vars` | Copies renewed certs into Nomad variables | Pinned to `duckseason`; triggers nginx reload via variable update |
+| `newt` | Pangolin tunnel client | Connects to external Pangolin server for remote access |
+| `nut2mqtt` | UPS stats → MQTT | Reads from NUT daemons on UPS-attached hosts |
+| `postfix-andvari-smarthost` | Internal Postfix smarthost | Relays outbound mail |
+| `dns` | Consul-aware DNS | BIND9 forwarding `.consul` to local Consul agent |
+| `z2m` | Zigbee2MQTT | See apps/ — listed here too as it's infrastructure for HASS |
+
+## SSL certificate pipeline
+
+Certificates are renewed by `certbot` and then propagated automatically:
+
+```
+certbot (runs on duckseason, writes to /export/things/docker/ssl)
+  → letsencrypt-to-nomad-vars (reads certs, writes to Nomad vars)
+    → web job template watches vars, sends SIGHUP to nginx on change
+```
+
+This means certificate renewals reach nginx without any manual steps or
+container restarts.

--- a/nomad/infra/letsencrypt-to-nomad-vars/letsencrypt-to-nomad-vars.hcl
+++ b/nomad/infra/letsencrypt-to-nomad-vars/letsencrypt-to-nomad-vars.hcl
@@ -20,6 +20,8 @@ job "letsencrypt-to-nomad-vars" {
       driver = "docker" 
       env {
         DOMAINS = "home.andvari.net drone.home.andvari.net birbs.home.andvari.net"
+        # This job is pinned to duckseason, so ${attr.unique.hostname} is always
+        # "duckseason". Using the attribute avoids hardcoding the hostname string twice.
         NOMAD_SERVER = "${attr.unique.hostname}"
         CHECK_FREQUENCY_HRS = "24"
       }

--- a/nomad/infra/web/default.conf
+++ b/nomad/infra/web/default.conf
@@ -1,3 +1,10 @@
+# Upstreams use Consul service discovery via DNS.
+# 'resolve' tells nginx to re-resolve the hostname dynamically (needed because
+# Consul DNS answers change as services move between hosts).
+# 'resolver' points at the Consul-aware BIND server so .consul names resolve.
+# 'zone' allocates shared memory for nginx to track the upstream state; required
+# when using 'resolve'.
+
 upstream sonarr-backend {
   server sonarr.service.home.consul:8989 resolve;
   resolver 192.168.100.250;

--- a/nomad/infra/web/web.hcl
+++ b/nomad/infra/web/web.hcl
@@ -10,8 +10,12 @@ job "web" {
 
     task "nginx_server" {
 
+      // SSL certs are stored as Nomad variables by the letsencrypt-to-nomad-vars job.
+      // change_mode = "signal" + SIGHUP means nginx reloads its config automatically
+      // when a cert is renewed, without restarting the container.
+
       // home.andvari.net SSL
-      template { 
+      template {
         data = "{{ with nomadVar \"ssl_certs/home_andvari_net\" }}{{ .privkey }}{{ end }}"
         destination = "secrets/home.andvari.net-privkey.pem"
         change_mode = "signal"

--- a/nomad/infra/z2m/z2m.hcl
+++ b/nomad/infra/z2m/z2m.hcl
@@ -9,15 +9,19 @@ job "z2m" {
         attribute = "${attr.unique.hostname}"
         value = "picluster5"
       }
-      driver = "docker" 
+      driver = "docker"
+      # 'dialout' group gives access to the Conbee USB serial device (/dev/ttyACM*).
+      # 'nobody' keeps the process unprivileged otherwise.
       user = "nobody:dialout"
       config {
         image = "koenkk/zigbee2mqtt:2.9.0"
         volumes = [
           "/things/docker/z2m:/app/data",
+          # udev is needed so the container can detect the Conbee stick's device path.
           "/run/udev:/run/udev:ro",
         ]
         ports = ["z2m"]
+        # privileged is required for direct USB/serial device access.
         privileged = true
       }
       resources {

--- a/nomad/monitoring/README.md
+++ b/nomad/monitoring/README.md
@@ -1,0 +1,21 @@
+# nomad/monitoring
+
+Prometheus-based monitoring stack.
+
+| Job | What it is |
+|---|---|
+| `prometheus` | Metrics collection and alerting |
+| `grafana` | Dashboards |
+| `prom-alertmanager` | Alert routing (email notifications) |
+| `prom-blackbox-exporter` | HTTP and ICMP probes |
+| `prom-consul-exporter` | Consul cluster metrics |
+
+Prometheus config files (scrape targets, alert rules, recording rules) live in
+`monitoring/` at the repo root — they're bind-mounted into the prometheus container.
+
+To reload Prometheus config without restarting the container:
+
+```bash
+bash monitoring/reload_prometheus.sh
+bash monitoring/reload_prometheus_blackbox.sh  # for blackbox exporter
+```

--- a/nomad/storage/README.md
+++ b/nomad/storage/README.md
@@ -1,0 +1,32 @@
+# nomad/storage
+
+CSI storage plugin and volume definitions.
+
+## Plugin: rocketduck NFS
+
+`rocketduck-controller.hcl` and `rocketduck-node.hcl` deploy the
+[csi-plugin-nfs](https://gitlab.com/rocketduck/csi-plugin-nfs) from rocketduck.
+
+The controller job runs as a single instance; the node job runs as `type = "system"`
+(i.e. one instance on every Nomad client). Both need `network_mode = "host"` and
+`privileged = true` so that NFS mounts survive container lifecycle events.
+
+The NFS server is `tings` (the QNAP NAS), exporting `/srv`. Plugin ID is
+`tings-srv-nfs` — this must match between controller, node, and volume definitions.
+
+## Volumes
+
+Volume definitions live in `volumes/`. Each `.hcl` file defines a named CSI volume
+that jobs can claim with a `volume` block:
+
+```hcl
+volume "mydata" {
+  type            = "csi"
+  source          = "mydata"
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}
+```
+
+Volumes are created once with `nomad volume create volumes/mydata.hcl` and then
+persist independently of job deployments.


### PR DESCRIPTION
READMEs added:
- ansible/README.md: host groups, roles, how to run
- nomad/README.md: directory layout, secrets pattern
- nomad/apps/README.md: app inventory, hardware-pinned jobs
- nomad/infra/README.md: infra services, SSL cert pipeline
- nomad/monitoring/README.md: monitoring stack, reload scripts
- nomad/storage/README.md: CSI plugin, volume workflow
- nomad/acl/README.md: ACL policies
- nomad/cron/README.md: periodic jobs
- monitoring/README.md: prometheus config files, reload
- cicd/README.md: HAProxy stubs

Inline comments added:
- consul.hcl.j2: why TLS verification and ACL are disabled
- nomad.hcl: why allow_privileged and raw_exec are enabled
- hass.hcl: why PYTHONPATH/PYTHONUSERBASE point into /config
- octoprint.hcl: why privileged + host networking are needed
- z2m.hcl: why dialout group, udev mount, and privileged are needed
- web.hcl: explain SIGHUP cert-reload pattern
- default.conf: explain resolver/resolve/zone pattern for Consul DNS
- letsencrypt-to-nomad-vars.hcl: explain ${attr.unique.hostname} usage
- prometheus.yml: explain static targets and non-default scrape intervals