### PR TITLE
fix: add --entrypoint promtool to prometheus docker run

### DIFF
--- a/.github/workflows/monitoring-validate.yml
+++ b/.github/workflows/monitoring-validate.yml
@@ -19,9 +19,10 @@ jobs:
       - name: Validate prometheus config
         run: |
           docker run --rm \
+            --entrypoint promtool \
             -v "$GITHUB_WORKSPACE/monitoring:/monitoring:ro" \
             prom/prometheus:v3.10.0 \
-            promtool check config /monitoring/prometheus.yml
+            check config /monitoring/prometheus.yml
 
       - name: Validate alertmanager config
         run: |

--- a/scripts/check-monitoring-configs.sh
+++ b/scripts/check-monitoring-configs.sh
@@ -9,9 +9,10 @@ echo "==> Checking monitoring configs in ${MONITORING_DIR}"
 echo ""
 echo "--- prometheus config ---"
 docker run --rm \
+  --entrypoint promtool \
   -v "${MONITORING_DIR}:/monitoring:ro" \
   prom/prometheus:v3.10.0 \
-  promtool check config /monitoring/prometheus.yml
+  check config /monitoring/prometheus.yml
 echo "PASS: prometheus config"
 
 echo ""


### PR DESCRIPTION
prom/prometheus defaults to the prometheus binary as entrypoint, so promtool must be specified as --entrypoint, not as an argument.