### PR TITLE
fix: add missing service stanza to prom-alertmanager

### DIFF
--- a/nomad/monitoring/prom-alertmanager.hcl
+++ b/nomad/monitoring/prom-alertmanager.hcl
@@ -19,7 +19,11 @@ job "prom-alertmanager" {
     }
 
     task "prom-alertmanager_server" {
-      driver = "docker" 
+      service {
+        name = "prom-alertmanager"
+        port = "prom-alertmanager"
+      }
+      driver = "docker"
 
       config {
         image = "prom/alertmanager"


### PR DESCRIPTION
Without a Consul service registration, prom-alertmanager.service.home.consul doesn't resolve and the webhook reload POST fails.