### PR TITLE
fix: correct alertmanager config filename

### DIFF
--- a/nomad/monitoring/prom-alertmanager.hcl
+++ b/nomad/monitoring/prom-alertmanager.hcl
@@ -27,7 +27,7 @@ job "prom-alertmanager" {
 
       config {
         image = "prom/alertmanager"
-        args = ["--config.file=/config/monitoring/alertmanager.yml",
+        args = ["--config.file=/config/monitoring/prom-alertmanager.yml",
                 "--web.external-url=http://prom-alertmanager.home.nomad.andvari.net:9093/",
                 "--storage.path=/data/prom-alertmanager"]
         labels {


### PR DESCRIPTION
## Summary
- `prom-alertmanager.hcl` was pointing at `alertmanager.yml` but the file in the repo is `prom-alertmanager.yml`, causing alertmanager to fail on startup.

## Test plan
- [ ] Deploy `nomad run nomad/monitoring/prom-alertmanager.hcl` and confirm alertmanager starts without a config-not-found error

🤖 Generated with [Claude Code](https://claude.com/claude-code)