### PR TITLE
monitoring: add availability probes for miniflux, mosquitto, mysql, postgres, newt, z2m

### DIFF
--- a/monitoring/blackbox_alerting_rules.yml
+++ b/monitoring/blackbox_alerting_rules.yml
@@ -27,7 +27,7 @@
       "description": "{{ $labels.instance }} is not responding"
       "summary": "{{ $labels.instance }} is not responding"
     "expr": |
-      probe_success{job="blackbox-consul-http"} < 1
+      probe_success{job=~"blackbox-consul-.*"} < 1
     "for": "5m"
     "labels":
       "severity": "critical"

--- a/monitoring/prom-blackbox-exporter.yml
+++ b/monitoring/prom-blackbox-exporter.yml
@@ -1,16 +1,34 @@
-modules: 
-  http_2xx: 
-    http: 
-      fail_if_not_ssl: true
-      ip_protocol_fallback: false
-      method: GET
-      no_follow_redirects: false
-      preferred_ip_protocol: ip4
-      valid_http_versions: 
-        - HTTP/1.1
-        - HTTP/2.0
+modules:
+  # For external HTTPS URLs -- fails if not SSL.
+  http_2xx:
     prober: http
     timeout: 15s
+    http:
+      method: GET
+      preferred_ip_protocol: ip4
+      ip_protocol_fallback: false
+      no_follow_redirects: false
+      valid_http_versions:
+        - HTTP/1.1
+        - HTTP/2.0
+      fail_if_not_ssl: true
+
+  # For internal plain-HTTP services.
+  http_2xx_internal:
+    prober: http
+    timeout: 10s
+    http:
+      method: GET
+      preferred_ip_protocol: ip4
+      ip_protocol_fallback: false
+      valid_http_versions:
+        - HTTP/1.1
+        - HTTP/2.0
+
+  # For non-HTTP TCP services (MQTT, MySQL, PostgreSQL, etc.)
+  tcp_connect:
+    prober: tcp
+    timeout: 5s
 
   icmp:
     prober: icmp

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -80,11 +80,11 @@ scrape_configs:
       - target_label: __address__
         replacement: prom-blackbox-exporter.service.home.consul:9115
 
-  # HTTP availability probes for known consul services.
+  # HTTP availability probes for internal consul services (plain HTTP).
   - job_name: blackbox-consul-http
     metrics_path: /probe
     params:
-      module: [http_2xx]
+      module: [http_2xx_internal]
     static_configs:
       - targets:
           - prometheus.service.home.consul:9090
@@ -93,6 +93,8 @@ scrape_configs:
           - prom-consul-exporter.service.home.consul:9107
           - grafana.service.home.consul:3000
           - nut2mqtt.service.home.consul:3494
+          - miniflux.service.home.consul:8822
+          - z2m.service.home.consul:8081
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target
@@ -100,6 +102,29 @@ scrape_configs:
         target_label: instance
       - target_label: __address__
         replacement: prom-blackbox-exporter.service.home.consul:9115
+
+  # TCP availability probes for non-HTTP consul services.
+  - job_name: blackbox-consul-tcp
+    metrics_path: /probe
+    params:
+      module: [tcp_connect]
+    static_configs:
+      - targets:
+          - mosquitto.service.home.consul:1883
+          - mysql.service.home.consul:3306
+          - postgres.service.home.consul:5432
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: prom-blackbox-exporter.service.home.consul:9115
+
+  # Newt tunnel client metrics (built-in Prometheus endpoint).
+  - job_name: newt
+    static_configs:
+      - targets: ['newt.service.home.consul:2112']
 
   # ICMP ping probes for physical hosts.
   # 1m interval: more frequent than this causes alert flapping on transient packet loss.

--- a/nomad/infra/newt/newt.hcl
+++ b/nomad/infra/newt/newt.hcl
@@ -2,32 +2,44 @@ job "newt" {
   datacenters = ["home"]
   group "newt_servers" {
     count = 1
-     constraint {
+    constraint {
       distinct_hosts = true
-    }  
+    }
     task "newt" {
-      driver = "docker" 
+      service {
+        name = "newt"
+        port = "metrics"
+      }
+      driver = "docker"
       config {
         image = "fosrl/newt"
         labels {
           group = "newt"
         }
+        ports = ["metrics"]
       }
-     template {
-       data = <<EOH
+      template {
+        data = <<EOH
 {{- with nomadVar "nomad/jobs/newt" -}}
 PANGOLIN_ENDPOINT={{ .endpoint }}
 NEWT_ID={{ .id }}
 NEWT_SECRET={{ .secret }}
 {{- end -}}
 EOH
-      destination = "secrets/newt.txt"
-      env = true
+        destination = "secrets/newt.txt"
+        env = true
+      }
+      env {
+        TZ                              = "Europe/Dublin"
+        NEWT_METRICS_PROMETHEUS_ENABLED = "true"
+        NEWT_ADMIN_ADDR                 = "0.0.0.0:2112"
+      }
     }
-     env {
-       TZ = "Europe/Dublin"
-     }
+
+    network {
+      port "metrics" {
+        static = "2112"
+      }
     }
   }
 }
-

--- a/nomad/infra/z2m/z2m.hcl
+++ b/nomad/infra/z2m/z2m.hcl
@@ -4,6 +4,10 @@ job "z2m" {
   group "z2m_servers" {
    
     task "z2m_server" {
+      service {
+        name = "z2m"
+        port = "z2m"
+      }
       # The machine with the conbee.
       constraint {
         attribute = "${attr.unique.hostname}"


### PR DESCRIPTION
## Summary
- Add `http_2xx_internal` (plain HTTP) and `tcp_connect` modules to blackbox exporter config
- Fix `blackbox-consul-http` to use `http_2xx_internal` — internal services don't use TLS
- Add HTTP probes for miniflux and z2m to `blackbox-consul-http`
- Add `blackbox-consul-tcp` job for mosquitto (1883), mysql (3306), postgres (5432)
- Add `newt` scrape job using newt's built-in Prometheus metrics endpoint
- Broaden `ConsulServiceDown` alert to cover both `blackbox-consul-http` and `blackbox-consul-tcp`
- Add service stanza to z2m.hcl so `z2m.service.home.consul` resolves
- Enable newt metrics endpoint via env vars, expose port 2112, add service stanza

## Test plan
- [ ] Deploy updated `prom-blackbox-exporter` and `prometheus` jobs
- [ ] Deploy updated `z2m` and `newt` jobs
- [ ] Check prometheus targets page — all new targets should show as UP
- [ ] Verify `ConsulServiceDown` alert fires correctly if a service is stopped

🤖 Generated with [Claude Code](https://claude.com/claude-code)