### PR TITLE
fix: use consul address for alertmanager smarthost

### DIFF
--- a/monitoring/prom-alertmanager.yml
+++ b/monitoring/prom-alertmanager.yml
@@ -1,5 +1,5 @@
 global:
-  smtp_smarthost: 'smtp:25'
+  smtp_smarthost: 'postfix-andvari-smarthost.service.home.consul:25'
   smtp_from: 'alerts@mail.andvari.net'
 
 

--- a/nomad/monitoring/prom-alertmanager.hcl
+++ b/nomad/monitoring/prom-alertmanager.hcl
@@ -28,7 +28,6 @@ job "prom-alertmanager" {
       config {
         image = "prom/alertmanager"
         args = ["--config.file=/config/monitoring/prom-alertmanager.yml",
-                "--web.external-url=http://prom-alertmanager.home.nomad.andvari.net:9093/",
                 "--storage.path=/data/prom-alertmanager"]
         labels {
           group = "prom-alertmanager"


### PR DESCRIPTION
## Summary
- Update `monitoring/prom-alertmanager.yml` to use `postfix-andvari-smarthost.service.home.consul:25` instead of bare `smtp:25`
- Drop stale `--web.external-url` nomad DNS arg from `nomad/monitoring/prom-alertmanager.hcl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)