### PR TITLE
traefik: remove debug logging

### DIFF
--- a/nomad/infra/traefik/traefik.hcl
+++ b/nomad/infra/traefik/traefik.hcl
@@ -110,15 +110,7 @@ api:
 ping: {}
 
 log:
-  level: DEBUG
-
-accessLog:
-  fields:
-    headers:
-      defaultMode: drop
-      names:
-        X-Forwarded-For: keep
-        X-Real-Ip: keep
+  level: INFO
 EOH
         destination = "local/traefik.yml"
       }


### PR DESCRIPTION
Remove access log header capture and drop log level back to INFO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)