### PR TITLE
fix: use consul addresses for prometheus/alertmanager external URLs

### DIFF
--- a/nomad/monitoring/prom-alertmanager.hcl
+++ b/nomad/monitoring/prom-alertmanager.hcl
@@ -28,7 +28,8 @@ job "prom-alertmanager" {
       config {
         image = "prom/alertmanager"
         args = ["--config.file=/config/monitoring/prom-alertmanager.yml",
-                "--storage.path=/data/prom-alertmanager"]
+                "--storage.path=/data/prom-alertmanager",
+                "--web.external-url=http://prom-alertmanager.service.home.consul:9093/"]
         labels {
           group = "prom-alertmanager"
         }

--- a/nomad/monitoring/prometheus.hcl
+++ b/nomad/monitoring/prometheus.hcl
@@ -30,7 +30,7 @@ job "prometheus" {
         args = ["--config.file=/config/monitoring/prometheus.yml",
                 "--storage.tsdb.path=/data/prometheus/prom-tsdb/",
                 # URL to pass to alertmanager etc.
-                "--web.external-url=http://prometheus.home.nomad.andvari.net:9090/",
+                "--web.external-url=http://prometheus.service.home.consul:9090/",
                 # Enable reload via web
                 "--web.enable-lifecycle"]
         labels {


### PR DESCRIPTION
## Summary

- Fix `--web.external-url` in prometheus to use `prometheus.service.home.consul:9090` instead of the old `*.home.nomad.andvari.net` hostname
- Add `--web.external-url` to alertmanager pointing at `prom-alertmanager.service.home.consul:9093` (was missing entirely)

These URLs appear in alert notification emails as "View in Prometheus" / "View in Alertmanager" links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)