### PR TITLE
docs: update READMEs to reflect current state

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,7 +1,7 @@
 # monitoring
 
-Prometheus configuration files, bind-mounted into the prometheus container by
-the Nomad job in `nomad/monitoring/prometheus.hcl`.
+Prometheus configuration files, mounted into the prometheus container via the
+`gitrepo` CSI volume by the Nomad job in `nomad/monitoring/prometheus.hcl`.
 
 | File | Purpose |
 |---|---|

--- a/nomad/README.md
+++ b/nomad/README.md
@@ -8,7 +8,7 @@ Nomad job definitions for everything running on the cluster.
 |---|---|
 | `apps/` | User-facing applications |
 | `infra/` | Infrastructure services (databases, web, MQTT, DNS, certs, email) |
-| `monitoring/` | Prometheus, Grafana, Alertmanager, and exporters |
+| `monitoring/` | Prometheus, Alertmanager, and exporters |
 | `storage/` | CSI plugin (NFS) and volume definitions |
 | `cron/` | Periodic batch jobs |
 | `acl/` | Nomad ACL policies |

--- a/nomad/infra/README.md
+++ b/nomad/infra/README.md
@@ -19,7 +19,7 @@ Traefik handles the full certificate lifecycle automatically:
 
 ```
 Traefik (runs on hedwig, port 80/443)
-  → DNS-01 ACME challenge via GCP Cloud DNS (cloud_dns_key Nomad variable)
+  → DNS-01 ACME challenge via GCP Cloud DNS (gcp_credentials_json in nomad/jobs/traefik Nomad variable)
     → Certificates stored in /localssd/traefik/acme.json on hedwig
       → Served directly by Traefik; renewed automatically before expiry
 ```

--- a/nomad/infra/traefik/README.md
+++ b/nomad/infra/traefik/README.md
@@ -161,6 +161,16 @@ certs from scratch and you may hit Let's Encrypt rate limits.
 
 ## IP restriction
 
-The `internal-only@file` middleware restricts access to `192.168.100.0/24`.
-Apply it to any router that should not be reachable from the internet.
-To make a route fully public, omit the `middlewares` tag/key entirely.
+The `internal-only@file` middleware restricts access to `192.168.100.0/24`
+plus an optional home IP read from the `home_ip` key in the `nomad/jobs/traefik`
+Nomad variable (stored as a `/32`, kept out of the public config).
+
+The middleware uses `ipStrategy.depth: 1` to evaluate the leftmost
+`X-Forwarded-For` IP rather than the raw connection address. This is required
+because traffic arriving via Pangolin/Newt (the remote access tunnel) appears
+to originate from the Docker bridge or a Nomad host LAN IP rather than the
+actual client. Traefik's entrypoints trust `X-Forwarded-For` from
+`172.17.0.0/16` and `192.168.100.0/24` via `forwardedHeaders.trustedIPs`.
+
+Apply `internal-only` to any router that should not be reachable from the
+internet. To make a route fully public, omit the `middlewares` tag/key entirely.

--- a/nomad/monitoring/README.md
+++ b/nomad/monitoring/README.md
@@ -5,17 +5,17 @@ Prometheus-based monitoring stack.
 | Job | What it is |
 |---|---|
 | `prometheus` | Metrics collection and alerting |
-
 | `prom-alertmanager` | Alert routing (email notifications) |
 | `prom-blackbox-exporter` | HTTP and ICMP probes |
 | `prom-consul-exporter` | Consul cluster metrics |
 
 Prometheus config files (scrape targets, alert rules, recording rules) live in
-`monitoring/` at the repo root — they're bind-mounted into the prometheus container.
+`monitoring/` at the repo root — mounted into the prometheus container via the
+`gitrepo` CSI volume.
 
 To reload Prometheus config without restarting the container:
 
 ```bash
-bash monitoring/reload_prometheus.sh
-bash monitoring/reload_prometheus_blackbox.sh  # for blackbox exporter
+bash scripts/reload_prometheus.sh
+bash scripts/reload_prometheus_blackbox.sh  # for blackbox exporter
 ```


### PR DESCRIPTION
## Summary

- Remove Grafana from `nomad/README.md` (removed in #35)
- Fix reload script paths in `nomad/monitoring/README.md` (`scripts/` not `monitoring/`), fix table formatting, fix CSI volume vs bind-mount description
- Fix cert pipeline variable name in `nomad/infra/README.md` (`gcp_credentials_json`, not `cloud_dns_key`)
- Document updated IP restriction behaviour in `nomad/infra/traefik/README.md`: `home_ip` Nomad variable, `ipStrategy.depth:1`, `forwardedHeaders.trustedIPs` for Pangolin/Newt tunnel traffic
- Fix CSI volume vs bind-mount in `monitoring/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)