### PR TITLE
Fix miniflux blackbox probe to hit /rss

### DIFF
--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -93,7 +93,7 @@ scrape_configs:
           - prom-consul-exporter.service.home.consul:9107
 
           - nut2mqtt.service.home.consul:3494
-          - miniflux.service.home.consul:8080
+          - http://miniflux.service.home.consul:8080/rss
           - z2m.service.home.consul:8081
     relabel_configs:
       - source_labels: [__address__]


### PR DESCRIPTION
## Summary
- Miniflux returns 404 on `/` — changed the blackbox probe target to `/rss` which returns 200

## Test plan
- [ ] Confirm blackbox probe for miniflux shows `probe_success=1` after homelab-webhook reloads prometheus config