### PR TITLE
Add rabbitseason as NFS server (srv, mix exports)

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -20,7 +20,7 @@ encrypt Consul cluster gossip traffic and must match across all nodes.
 | Group | Hosts | Purpose |
 |---|---|---|
 | `nomadconsul` | picluster2/4/5, duckseason, hedwig, donkeh, bebop, rocksteady | Nomad clients+servers and Consul agents |
-| `nfs_server` | duckseason | Exports `/export/things` over NFS |
+| `nfs_server` | duckseason, rabbitseason | NFS servers: duckseason exports `/export/things`; rabbitseason exports `/srv` (from `/localssd/srv`) and `/mix` (from `/localdisk/mix`) |
 | `dns_server` | hedwig, donkeh, duckseason | BIND9 with Consul forwarding for `.consul` queries |
 | `ups` | hedwig, duckseason | NUT for UPS monitoring |
 | `login` | rabbitseason | Public-facing SSH login node |
@@ -40,6 +40,7 @@ encrypt Consul cluster gossip traffic and must match across all nodes.
 | `remove_k8s` | Strips Kubernetes packages and data dirs from a host being converted to Nomad |
 | `linux_aptlike` | Common baseline packages for apt-based hosts |
 | `login` | SSH hardening and user config for the login node |
+| `nfs_server` | Bind-mounts source paths to NFS export paths (runs after `ansible-nfs-server`); configured via `nfs_server_bindmounts` host var |
 | `ups` | NUT client config for hosts with a locally attached UPS |
 | `publicsmtp` | Postfix + OpenDKIM for the public-facing mail relay |
 | `publicweb` | nginx config for static public web hosting |


### PR DESCRIPTION
## Summary

- Adds `rabbitseason` to the `nfs_server` inventory group
- Exports `/srv` (bind-mounted from `/localssd/srv`) and `/mix` (bind-mounted from `/localdisk/mix`), accessible as `rabbitseason:/srv` and `rabbitseason:/mix`
- Same access rules as duckseason's `/export/things`: `rw,sync,no_subtree_check` for `192.168.100.240/28` and `localhost`
- Moves duckseason's `nfs_server_exports` from group vars to host vars so each host has its own independent export list

## New `nfs_server` role

Runs bind mounts after `ansible-nfs-server` sets up the NFS server. Controlled by the `nfs_server_bindmounts` host var (list of `src`/`dest` pairs). Bind mount failures are non-fatal so a disk not being ready doesn't block NFS server setup.

## Submodule update

Bumps `ansible-nfs-server` from `2c20ba5` to `f35ec75` to fix removal of `ansible.builtin.include` in recent ansible-core.

## Test plan

- [ ] `git submodule update --init ansible/roles/ansible-nfs-server`
- [ ] `ansible-playbook -i inventory.yml site.yml --limit=rabbitseason` — verify `/etc/exports` contains `/srv` and `/mix`, and bind mounts are active
- [ ] Confirm duckseason's `/export/things` export is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)