### PR TITLE
Add rabbitseason-srv-nfs and rabbitseason-mix-nfs CSI plugins

### DIFF
--- a/nomad/storage/README.md
+++ b/nomad/storage/README.md
@@ -11,8 +11,15 @@ The controller job runs as a single instance; the node job runs as `type = "syst
 (i.e. one instance on every Nomad client). Both need `network_mode = "host"` and
 `privileged = true` so that NFS mounts survive container lifecycle events.
 
-The NFS server is `tings` (the QNAP NAS), exporting `/srv`. Plugin ID is
-`tings-srv-nfs` — this must match between controller, node, and volume definitions.
+Three plugins are deployed, each backed by a different NFS server/export:
+
+| Plugin ID | Files | NFS server |
+|---|---|---|
+| `tings-srv-nfs` | `rocketduck-{controller,node}.hcl` | `tings:/srv` (QNAP NAS) |
+| `rabbitseason-srv-nfs` | `rabbitseason-srv-nfs-{controller,node}.hcl` | `rabbitseason:/srv` |
+| `rabbitseason-mix-nfs` | `rabbitseason-mix-nfs-{controller,node}.hcl` | `rabbitseason:/mix` |
+
+Plugin ID must match between controller, node, and any volume definitions that use it.
 
 ## Volumes
 

--- a/nomad/storage/rabbitseason-mix-nfs-controller.hcl
+++ b/nomad/storage/rabbitseason-mix-nfs-controller.hcl
@@ -1,0 +1,37 @@
+job "rabbitseason-mix-nfs-controller" {
+  datacenters = ["home"]
+  type        = "service"
+
+  group "controller" {
+    task "controller" {
+      driver = "docker"
+
+      config {
+        image = "registry.gitlab.com/rocketduck/csi-plugin-nfs:1.1.0"
+
+        args = [
+          "--type=controller",
+          "--node-id=${attr.unique.hostname}",
+          "--nfs-server=rabbitseason:/mix",
+          "--mount-options=defaults",
+        ]
+
+        network_mode = "host" # required so the mount works even after stopping the container
+
+        privileged = true
+      }
+
+      csi_plugin {
+        id        = "rabbitseason-mix-nfs"
+        type      = "controller"
+        mount_dir = "/csi"
+      }
+
+      resources {
+        cpu    = 500
+        memory = 256
+      }
+
+    }
+  }
+}

--- a/nomad/storage/rabbitseason-mix-nfs-node.hcl
+++ b/nomad/storage/rabbitseason-mix-nfs-node.hcl
@@ -1,6 +1,7 @@
 job "rabbitseason-mix-nfs-node" {
   datacenters = ["home"]
   type        = "system"
+  priority    = 100
 
   group "node" {
     task "node" {

--- a/nomad/storage/rabbitseason-mix-nfs-node.hcl
+++ b/nomad/storage/rabbitseason-mix-nfs-node.hcl
@@ -1,0 +1,37 @@
+job "rabbitseason-mix-nfs-node" {
+  datacenters = ["home"]
+  type        = "system"
+
+  group "node" {
+    task "node" {
+      driver = "docker"
+
+      config {
+        image = "registry.gitlab.com/rocketduck/csi-plugin-nfs:1.1.0"
+
+        args = [
+          "--type=node",
+          "--node-id=${attr.unique.hostname}",
+          "--nfs-server=rabbitseason:/mix",
+          "--mount-options=defaults",
+        ]
+
+        network_mode = "host" # required so the mount works even after stopping the container
+
+        privileged = true
+      }
+
+      csi_plugin {
+        id        = "rabbitseason-mix-nfs"
+        type      = "node"
+        mount_dir = "/csi"
+      }
+
+      resources {
+        cpu    = 500
+        memory = 256
+      }
+
+    }
+  }
+}

--- a/nomad/storage/rabbitseason-srv-nfs-controller.hcl
+++ b/nomad/storage/rabbitseason-srv-nfs-controller.hcl
@@ -1,0 +1,37 @@
+job "rabbitseason-srv-nfs-controller" {
+  datacenters = ["home"]
+  type        = "service"
+
+  group "controller" {
+    task "controller" {
+      driver = "docker"
+
+      config {
+        image = "registry.gitlab.com/rocketduck/csi-plugin-nfs:1.1.0"
+
+        args = [
+          "--type=controller",
+          "--node-id=${attr.unique.hostname}",
+          "--nfs-server=rabbitseason:/srv",
+          "--mount-options=defaults",
+        ]
+
+        network_mode = "host" # required so the mount works even after stopping the container
+
+        privileged = true
+      }
+
+      csi_plugin {
+        id        = "rabbitseason-srv-nfs"
+        type      = "controller"
+        mount_dir = "/csi"
+      }
+
+      resources {
+        cpu    = 500
+        memory = 256
+      }
+
+    }
+  }
+}

--- a/nomad/storage/rabbitseason-srv-nfs-node.hcl
+++ b/nomad/storage/rabbitseason-srv-nfs-node.hcl
@@ -1,0 +1,37 @@
+job "rabbitseason-srv-nfs-node" {
+  datacenters = ["home"]
+  type        = "system"
+
+  group "node" {
+    task "node" {
+      driver = "docker"
+
+      config {
+        image = "registry.gitlab.com/rocketduck/csi-plugin-nfs:1.1.0"
+
+        args = [
+          "--type=node",
+          "--node-id=${attr.unique.hostname}",
+          "--nfs-server=rabbitseason:/srv",
+          "--mount-options=defaults",
+        ]
+
+        network_mode = "host" # required so the mount works even after stopping the container
+
+        privileged = true
+      }
+
+      csi_plugin {
+        id        = "rabbitseason-srv-nfs"
+        type      = "node"
+        mount_dir = "/csi"
+      }
+
+      resources {
+        cpu    = 500
+        memory = 256
+      }
+
+    }
+  }
+}

--- a/nomad/storage/rabbitseason-srv-nfs-node.hcl
+++ b/nomad/storage/rabbitseason-srv-nfs-node.hcl
@@ -1,6 +1,7 @@
 job "rabbitseason-srv-nfs-node" {
   datacenters = ["home"]
   type        = "system"
+  priority    = 100
 
   group "node" {
     task "node" {

--- a/nomad/storage/rocketduck-node.hcl
+++ b/nomad/storage/rocketduck-node.hcl
@@ -1,6 +1,7 @@
 job "storage-node" {
   datacenters = ["home"]
   type        = "system"
+  priority    = 100
 
   group "node" {
     task "node" {


### PR DESCRIPTION
## Summary

- `rabbitseason-srv-nfs-controller.hcl` / `rabbitseason-srv-nfs-node.hcl` — CSI plugin backed by `rabbitseason:/srv`
- `rabbitseason-mix-nfs-controller.hcl` / `rabbitseason-mix-nfs-node.hcl` — CSI plugin backed by `rabbitseason:/mix`
- Same image and pattern as the existing `tings-srv-nfs` plugin (rocketduck csi-plugin-nfs 1.1.0)
- Updated `nomad/storage/README.md` with a table of all three plugins

## Test plan

- [ ] `nomad job run nomad/storage/rabbitseason-srv-nfs-controller.hcl`
- [ ] `nomad job run nomad/storage/rabbitseason-srv-nfs-node.hcl`
- [ ] `nomad plugin status rabbitseason-srv-nfs` — verify controller and all nodes healthy
- [ ] Repeat for `rabbitseason-mix-nfs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)