### PR TITLE
Enable Nomad preemption for all scheduler types

### DIFF
--- a/ansible/roles/nomad/files/server.hcl
+++ b/ansible/roles/nomad/files/server.hcl
@@ -1,4 +1,12 @@
 server {
   enabled = true
   bootstrap_expect = 3
+
+  default_scheduler_config {
+    preemption_config {
+      batch_scheduler_enabled   = true
+      service_scheduler_enabled = true
+      system_scheduler_enabled  = true
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Adds `default_scheduler_config` to `server.hcl` enabling preemption for batch, service, and system schedulers.

This allows high-priority jobs (e.g. CSI node plugins at `priority = 100`) to evict lower-priority jobs when a node is resource-constrained, ensuring infrastructure jobs always schedule.

## Notes

- `default_scheduler_config` sets the initial scheduler config on cluster bootstrap. It can be overridden at runtime via `nomad operator scheduler set-config`, but this ensures the right defaults from first boot.
- Existing clusters: re-running the Ansible playbook will update `server.hcl` and restart Nomad servers, which will pick up the new default (unless the config has been overridden via the API).

## Test plan

- [ ] Apply playbook to Nomad server nodes
- [ ] `nomad operator scheduler get-config` — verify all three preemption flags are `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)