### PR TITLE
Add pgbackup: daily encrypted postgres dumps to NFS volume

### DIFF
--- a/nomad/infra/postgres/README.md
+++ b/nomad/infra/postgres/README.md
@@ -1,0 +1,110 @@
+# postgres
+
+Runs a single PostgreSQL 16 instance pinned to `hedwig`, with a `pgbackup`
+sidecar that writes daily encrypted dumps to a CSI volume.
+
+## Jobs / tasks
+
+| Task | Purpose |
+|---|---|
+| `postgres` | PostgreSQL 16.13 server, data on `/localssd/postgres` |
+| `pgbackup` | Sidecar: dumps all non-system databases daily, encrypted |
+
+## Prerequisites
+
+### Nomad variables
+
+Both tasks read from `nomad/jobs/postgres`. Create it with:
+
+```
+nomad var put nomad/jobs/postgres \
+  pgpassword=<password> \
+  pgbackup_key=<encryption-passphrase>
+```
+
+`pgbackup_key` is a passphrase used with `openssl enc -aes-256-cbc -pbkdf2`.
+Choose something strong and store it somewhere safe — you need it to restore.
+
+### CSI volume
+
+Create the backup volume once before first deploy:
+
+```
+nomad volume create nomad/storage/volumes/pgbackup.hcl
+```
+
+## Backup details
+
+`pgbackup.sh` runs a loop: on start it waits for postgres to accept
+connections, dumps every database where `datistemplate = false`, then sleeps
+24 hours and repeats. System databases (`template0`, `template1`) are
+excluded; the `postgres` database is included.
+
+Each database produces one file on the `pgbackup` CSI volume
+(`rabbitseason:/mix`):
+
+```
+/backup/<dbname>.sql.enc
+```
+
+The file is the output of `pg_dump | openssl enc -aes-256-cbc -pbkdf2`,
+overwritten on each run. Version history is kept by restic, which backs up
+the NFS volume separately.
+
+The backup script lives at `nomad/infra/postgres/pgbackup.sh` in this repo
+and is executed directly from the `gitrepo` CSI volume mount — no rebuild
+needed when the script changes.
+
+## Restoring a backup
+
+### 1. Retrieve the encrypted dump from restic
+
+```bash
+# List snapshots to find the one you want
+bash scripts/restic-env.sh restic snapshots
+
+# Restore a specific snapshot to a local directory
+bash scripts/restic-env.sh restic restore <snapshot-id> \
+  --target /tmp/pgrestore \
+  --include '<mount-path>/backup/<dbname>.sql.enc'
+```
+
+### 2. Get the encryption key
+
+```bash
+nomad var get -out table nomad/jobs/postgres
+# note the value of pgbackup_key
+```
+
+### 3. Decrypt the dump
+
+```bash
+export PGBACKUP_KEY=<key-from-above>
+openssl enc -d -aes-256-cbc -pbkdf2 \
+  -pass env:PGBACKUP_KEY \
+  -in /tmp/pgrestore/<dbname>.sql.enc \
+  -out /tmp/<dbname>.sql
+```
+
+### 4. Restore to postgres
+
+For a full replacement of an existing database:
+
+```bash
+# Drop and recreate (adjust connection flags as needed)
+psql -h postgres.service.home.consul -U postgres \
+  -c "DROP DATABASE IF EXISTS <dbname>;"
+psql -h postgres.service.home.consul -U postgres \
+  -c "CREATE DATABASE <dbname>;"
+psql -h postgres.service.home.consul -U postgres \
+  -d <dbname> < /tmp/<dbname>.sql
+```
+
+To restore into a new database without touching the original:
+
+```bash
+psql -h postgres.service.home.consul -U postgres \
+  -c "CREATE DATABASE <dbname>_restored;"
+psql -h postgres.service.home.consul -U postgres \
+  -d <dbname>_restored < /tmp/<dbname>.sql
+```

--- a/nomad/infra/postgres/pgbackup.sh
+++ b/nomad/infra/postgres/pgbackup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Daily encrypted dump of all non-system postgres databases.
+# Runs as a sidecar task alongside the postgres job.
+# Required env vars (injected by Nomad template):
+#   PGPASSWORD    - postgres superuser password
+#   PGBACKUP_KEY  - passphrase for openssl encryption
+set -euo pipefail
+
+PGHOST=127.0.0.1
+PGUSER=postgres
+BACKUP_DIR=/backup
+
+until pg_isready -h "$PGHOST" -U "$PGUSER" -q; do
+  echo "Waiting for postgres..."
+  sleep 5
+done
+
+while true; do
+  echo "Starting backup at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  DATABASES=$(psql -h "$PGHOST" -U "$PGUSER" -t -A \
+    -c "SELECT datname FROM pg_database WHERE datistemplate = false")
+
+  for db in $DATABASES; do
+    echo "Backing up ${db}..."
+    pg_dump -h "$PGHOST" -U "$PGUSER" "$db" \
+      | openssl enc -aes-256-cbc -pbkdf2 -pass env:PGBACKUP_KEY \
+      > "$BACKUP_DIR/${db}.sql.enc"
+    echo "Done: ${db}.sql.enc"
+  done
+
+  echo "Backup complete. Sleeping 24h."
+  sleep 86400
+done

--- a/nomad/infra/postgres/postgres.hcl
+++ b/nomad/infra/postgres/postgres.hcl
@@ -17,7 +17,7 @@ job "postgres" {
         attribute = "${attr.unique.hostname}"
         value = "hedwig"
       }
-      driver = "docker" 
+      driver = "docker"
       config {
         image = "postgres:16.13"
         volumes = [
@@ -46,6 +46,83 @@ EOH
        TZ = "Europe/Dublin"
        PGDATA = "/var/lib/postgresql/data"
      }
+    }
+
+    task "pgbackup" {
+      driver = "docker"
+      config {
+        image   = "postgres:16.13"
+        command = "bash"
+        args    = ["/local/backup.sh"]
+      }
+
+      template {
+        data        = <<-EOH
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          PGHOST=127.0.0.1
+          PGUSER=postgres
+          BACKUP_DIR=/backup
+
+          until pg_isready -h "$PGHOST" -U "$PGUSER" -q; do
+            echo "Waiting for postgres..."
+            sleep 5
+          done
+
+          while true; do
+            DATE=$(date +%Y%m%d_%H%M%S)
+            echo "Starting backup at $DATE"
+
+            DATABASES=$(psql -h "$PGHOST" -U "$PGUSER" -t -A \
+              -c "SELECT datname FROM pg_database WHERE datistemplate = false")
+
+            for db in $DATABASES; do
+              echo "Backing up $db..."
+              pg_dump -h "$PGHOST" -U "$PGUSER" "$db" \
+                | openssl enc -aes-256-cbc -pbkdf2 -pass env:PGBACKUP_KEY \
+                > "$BACKUP_DIR/${db}_${DATE}.sql.enc"
+              pg_dump -h "$PGHOST" -U "$PGUSER" --schema-only "$db" \
+                | openssl enc -aes-256-cbc -pbkdf2 -pass env:PGBACKUP_KEY \
+                > "$BACKUP_DIR/${db}_${DATE}_schema.sql.enc"
+              echo "Done backing up $db"
+            done
+
+            echo "Backup complete. Sleeping 24h."
+            sleep 86400
+          done
+        EOH
+        destination = "local/backup.sh"
+        perms       = "755"
+      }
+
+      template {
+        data = <<EOH
+{{- with nomadVar "nomad/jobs/postgres" -}}
+PGPASSWORD={{ .pgpassword }}
+PGBACKUP_KEY={{ .pgbackup_key }}
+{{- end -}}
+EOH
+        destination = "secrets/pgbackup_env"
+        env         = true
+      }
+
+      volume_mount {
+        volume      = "pgbackup"
+        destination = "/backup"
+      }
+
+      resources {
+        cpu    = 200
+        memory = 256
+      }
+    }
+
+    volume "pgbackup" {
+      type            = "csi"
+      source          = "pgbackup"
+      access_mode     = "single-node-writer"
+      attachment_mode = "file-system"
     }
 
     network {

--- a/nomad/infra/postgres/postgres.hcl
+++ b/nomad/infra/postgres/postgres.hcl
@@ -53,47 +53,18 @@ EOH
       config {
         image   = "postgres:16.13"
         command = "bash"
-        args    = ["/local/backup.sh"]
+        args    = ["/gitrepo/nomad/infra/postgres/pgbackup.sh"]
       }
 
-      template {
-        data        = <<-EOH
-          #!/usr/bin/env bash
-          set -euo pipefail
+      volume_mount {
+        volume      = "gitrepo"
+        destination = "/gitrepo"
+        read_only   = true
+      }
 
-          PGHOST=127.0.0.1
-          PGUSER=postgres
-          BACKUP_DIR=/backup
-
-          until pg_isready -h "$PGHOST" -U "$PGUSER" -q; do
-            echo "Waiting for postgres..."
-            sleep 5
-          done
-
-          while true; do
-            DATE=$(date +%Y%m%d_%H%M%S)
-            echo "Starting backup at $DATE"
-
-            DATABASES=$(psql -h "$PGHOST" -U "$PGUSER" -t -A \
-              -c "SELECT datname FROM pg_database WHERE datistemplate = false")
-
-            for db in $DATABASES; do
-              echo "Backing up $db..."
-              pg_dump -h "$PGHOST" -U "$PGUSER" "$db" \
-                | openssl enc -aes-256-cbc -pbkdf2 -pass env:PGBACKUP_KEY \
-                > "$BACKUP_DIR/${db}_${DATE}.sql.enc"
-              pg_dump -h "$PGHOST" -U "$PGUSER" --schema-only "$db" \
-                | openssl enc -aes-256-cbc -pbkdf2 -pass env:PGBACKUP_KEY \
-                > "$BACKUP_DIR/${db}_${DATE}_schema.sql.enc"
-              echo "Done backing up $db"
-            done
-
-            echo "Backup complete. Sleeping 24h."
-            sleep 86400
-          done
-        EOH
-        destination = "local/backup.sh"
-        perms       = "755"
+      volume_mount {
+        volume      = "pgbackup"
+        destination = "/backup"
       }
 
       template {
@@ -107,15 +78,18 @@ EOH
         env         = true
       }
 
-      volume_mount {
-        volume      = "pgbackup"
-        destination = "/backup"
-      }
-
       resources {
         cpu    = 200
         memory = 256
       }
+    }
+
+    volume "gitrepo" {
+      type            = "csi"
+      source          = "gitrepo"
+      read_only       = true
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
     }
 
     volume "pgbackup" {

--- a/nomad/storage/volumes/pgbackup.hcl
+++ b/nomad/storage/volumes/pgbackup.hcl
@@ -1,0 +1,9 @@
+id = "pgbackup" # ID as seen in nomad
+name = "pgbackup" # Display name
+type = "csi"
+plugin_id = "rabbitseason-mix-nfs" # Needs to match the deployed plugin
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}


### PR DESCRIPTION
## Summary

- New CSI volume `pgbackup` on `rabbitseason-mix-nfs` for storing database dumps
- `pgbackup` sidecar task added to the postgres job: runs daily `pg_dump` for all non-system databases, encrypts output with `openssl aes-256-cbc` using a key from `nomad/jobs/postgres` Nomad variable (`pgbackup_key`)
- Backup script lives in `nomad/infra/postgres/pgbackup.sh` and is executed via the `gitrepo` CSI volume mount — no job redeploy needed when the script changes
- One `.sql.enc` file per database, overwritten each run; restic keeps version history
- README with deployment prerequisites and step-by-step restore instructions

## Pre-deploy checklist

- [ ] Add `pgbackup_key` to the `nomad/jobs/postgres` Nomad variable: `nomad var put nomad/jobs/postgres pgbackup_key=<passphrase>`
- [ ] Create the volume: `nomad volume create nomad/storage/volumes/pgbackup.hcl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)