### PR TITLE
Remove resticrunner (backups now run outside Nomad)

### DIFF
--- a/backpack.sh
+++ b/backpack.sh
@@ -69,10 +69,6 @@ echo "Starting periodic tasks..."
 
 nomad job run nomad/cron/git-pull-homelab.hcl
 
-echo "Scheduling backups..."
-
-nomad job run nomad/backups/resticrunner-docker.hcl
-
 echo "Starting Monitoring services..."
 
 nomad job run nomad/monitoring/prom-blackbox-exporter.hcl

--- a/nomad/infra/postgres/README.md
+++ b/nomad/infra/postgres/README.md
@@ -48,8 +48,8 @@ Each database produces one file on the `pgbackup` CSI volume
 ```
 
 The file is the output of `pg_dump | openssl enc -aes-256-cbc -pbkdf2`,
-overwritten on each run. Version history is kept by restic, which backs up
-the NFS volume separately.
+overwritten on each run. Version history is kept by whatever backs up the
+NFS volume externally.
 
 The backup script lives at `nomad/infra/postgres/pgbackup.sh` in this repo
 and is executed directly from the `gitrepo` CSI volume mount — no rebuild
@@ -61,10 +61,10 @@ needed when the script changes.
 
 ```bash
 # List snapshots to find the one you want
-bash scripts/restic-env.sh restic snapshots
+restic snapshots
 
-# Restore a specific snapshot to a local directory
-bash scripts/restic-env.sh restic restore <snapshot-id> \
+# Restore a specific file from a snapshot
+restic restore <snapshot-id> \
   --target /tmp/pgrestore \
   --include '<mount-path>/backup/<dbname>.sql.enc'
 ```


### PR DESCRIPTION
## Summary

- Remove `nomad job run nomad/backups/resticrunner-docker.hcl` from `backpack.sh`
- Update postgres README restore docs to use plain `restic` commands instead of the removed `scripts/restic-env.sh` helper

The `restic-backups` branch (never merged) can be deleted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)