### PR TITLE
Fix pgbackup stuck waiting for postgres

### DIFF
--- a/nomad/infra/postgres/pgbackup.sh
+++ b/nomad/infra/postgres/pgbackup.sh
@@ -6,7 +6,7 @@
 #   PGBACKUP_KEY  - passphrase for openssl encryption
 set -euo pipefail
 
-PGHOST=127.0.0.1
+PGHOST=postgres.service.home.consul
 PGUSER=postgres
 BACKUP_DIR=/backup
 


### PR DESCRIPTION
## Summary

`PGHOST` was set to `127.0.0.1`, but Docker tasks in the same Nomad group have separate network namespaces — loopback in the sidecar container doesn't reach the postgres container. Changed to `postgres.service.home.consul`, which is the correct pattern for inter-service communication in this cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)