### PR TITLE
Document inter-task networking gotcha in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ All Nomad services with a `service` stanza register in Consul and are resolvable
 
 Use these addresses (not `*.home.nomad.andvari.net`) everywhere — in prometheus scrape targets, reload URLs, inter-service references, and Traefik backend definitions.
 
+**Inter-task communication**: Docker tasks in the same Nomad group have separate network namespaces. Never use `127.0.0.1` to reach a sibling task — use its Consul DNS address instead.
+
 ## CSI volumes
 
 Key volumes:


### PR DESCRIPTION
## Summary

Adds a note to the Service DNS section: Docker tasks in the same Nomad group have separate network namespaces, so `127.0.0.1` doesn't reach sibling tasks — use Consul DNS. Learned the hard way with the pgbackup sidecar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)