### PR TITLE
feat: upgrade nomad-botherer to 0.0.2, add drift alert

### DIFF
--- a/monitoring/nomad_botherer_alerting_rules.yml
+++ b/monitoring/nomad_botherer_alerting_rules.yml
@@ -27,3 +27,16 @@
     "for": "0m"
     "labels":
       "severity": "warning"
+
+  # Fires if more than 3 jobs have a modified diff (definition in HCL differs
+  # from what's running in Nomad). Missing jobs are excluded -- use diff_type
+  # "missing_from_nomad" or "missing_from_hcl" to alert on those separately.
+  - "alert": "NomadJobDrift"
+    "annotations":
+      "summary": "{{ $value | humanize }} Nomad jobs have drifted from HCL"
+      "description": "{{ $value | humanize }} jobs are modified (running config differs from HCL). Run `curl nomad-botherer.service.home.consul:9112/diffs` for details."
+    "expr": |
+      nomad_botherer_drifted_jobs{diff_type="modified"} > 3
+    "for": "10m"
+    "labels":
+      "severity": "warning"

--- a/nomad/infra/homelab-webhook/homelab-webhook.hcl
+++ b/nomad/infra/homelab-webhook/homelab-webhook.hcl
@@ -82,7 +82,7 @@ EOF
       driver = "docker"
 
       config {
-        image = "ghcr.io/gerrowadat/nomad-botherer:latest"
+        image = "ghcr.io/gerrowadat/nomad-botherer:0.0.2"
         ports = ["nomad-botherer"]
       }
 


### PR DESCRIPTION
## Summary

- Pins nomad-botherer image to `0.0.2` (was `latest`)
- Adds `NomadJobDrift` alert: fires after 10m when `nomad_botherer_drifted_jobs{diff_type="modified"} > 3`

## Notes

`0.0.2` adds `nomad_botherer_drifted_jobs{diff_type}` with values `modified`, `missing_from_nomad`, and `missing_from_hcl`. The alert targets `modified` only — jobs where the running config diverges from the HCL definition. Missing jobs are a separate concern and not included.

The 10m `for` avoids alerting on transient drift during a rolling deploy.

## Test plan

- [ ] `nomad job run nomad/infra/homelab-webhook/homelab-webhook.hcl`
- [ ] Confirm `nomad_botherer_drifted_jobs` appears in `curl nomad-botherer.service.home.consul:9112/metrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)