### PR TITLE
feat: add kutt URL shortener at go.home.andvari.net

### DIFF
--- a/nomad/apps/README.md
+++ b/nomad/apps/README.md
@@ -11,6 +11,7 @@ User-facing applications.
 | `birdnet` | BirdNET-Pi bird call detection | Backed by CSI NFS volume |
 | `giv_tcp` | GivEnergy solar inverter monitoring | Talks to inverter at fixed LAN IP |
 | `cringesweeper` | Sweeps old posts from Bluesky and Mastodon | Secrets in `nomad/jobs/cringesweeper` |
+| `kutt` | URL shortener at go.home.andvari.net | Backed by postgres and CSI NFS volume; secrets in `nomad/jobs/kutt` |
 
 ## Hardware-pinned jobs
 

--- a/nomad/apps/kutt/README.md
+++ b/nomad/apps/kutt/README.md
@@ -1,0 +1,59 @@
+# kutt
+
+[kutt.it](https://github.com/thedevs-network/kutt) — self-hosted URL shortener.
+
+Served at `https://go.home.andvari.net` (internal only).
+
+## Dependencies
+
+- **Postgres** — `postgres.service.home.consul:5432`, database and user both named `kutt`
+- **SMTP** — `postfix-andvari-smarthost.service.home.consul:25`, no auth, from address `kutt@home.andvari.net`
+- **CSI volume** — `kutt`, backed by `rabbitseason-srv-nfs`, mounted at `/data`
+- **Traefik** — hostname routing, TLS via Let's Encrypt, `internal-only` middleware
+
+## First-time setup
+
+### 1. Create the postgres database and user
+
+Connect to postgres and run:
+
+```sql
+CREATE USER kutt WITH PASSWORD 'choose-a-password';
+CREATE DATABASE kutt OWNER kutt;
+```
+
+### 2. Create the Nomad variable
+
+```sh
+nomad var put nomad/jobs/kutt \
+  postgres_pass='the-password-from-above' \
+  jwt_secret='a-long-random-string'
+```
+
+Generate a suitable JWT secret with e.g. `openssl rand -hex 32`.
+
+### 3. Register the CSI volume
+
+```sh
+nomad volume create nomad/storage/volumes/kutt.hcl
+```
+
+The volume is served from `rabbitseason:/srv` via the `rabbitseason-srv-nfs` CSI plugin.
+
+### 4. Add DNS
+
+Add an A record for `go.home.andvari.net` pointing at Traefik (hedwig) in `dns/`.
+
+### 5. Deploy
+
+```sh
+nomad job run nomad/apps/kutt/kutt.hcl
+```
+
+Kutt runs database migrations automatically on first start.
+
+## Ongoing operation
+
+- Logs: `nomad alloc logs -job kutt`
+- The first account registered becomes an admin. Register at `https://go.home.andvari.net` after deploying.
+- To restrict registration after setup, set `DISALLOW_REGISTRATION=true` in the job template and redeploy.

--- a/nomad/apps/kutt/kutt.hcl
+++ b/nomad/apps/kutt/kutt.hcl
@@ -1,0 +1,79 @@
+job "kutt" {
+  datacenters = ["home"]
+
+  group "kutt_servers" {
+
+    volume "kutt" {
+      type            = "csi"
+      source          = "kutt"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
+    task "kutt_server" {
+      driver = "docker"
+
+      service {
+        name = "kutt"
+        port = "kutt"
+        tags = [
+          "traefik.enable=true",
+          "traefik.http.routers.kutt.rule=Host(`go.home.andvari.net`)",
+          "traefik.http.routers.kutt.tls=true",
+          "traefik.http.routers.kutt.tls.certresolver=le",
+          "traefik.http.routers.kutt.middlewares=internal-only@file",
+        ]
+        check {
+          name     = "HTTP Connection Check"
+          type     = "http"
+          path     = "/"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
+      template {
+        data = <<EOF
+DEFAULT_DOMAIN=go.home.andvari.net
+PORT=3000
+DB_CLIENT=pg
+DB_HOST=postgres.service.home.consul
+DB_PORT=5432
+DB_NAME=kutt
+DB_USER=kutt
+DB_PASSWORD={{ with nomadVar "nomad/jobs/kutt" }}{{ .postgres_pass }}{{ end }}
+JWT_SECRET={{ with nomadVar "nomad/jobs/kutt" }}{{ .jwt_secret }}{{ end }}
+MAIL_HOST=postfix-andvari-smarthost.service.home.consul
+MAIL_PORT=25
+MAIL_FROM=kutt@home.andvari.net
+MAIL_SECURE=false
+EOF
+        destination = "secrets/env"
+        env         = true
+      }
+
+      config {
+        image = "docker.io/kutt/kutt:latest"
+        ports = ["kutt"]
+      }
+
+      volume_mount {
+        volume      = "kutt"
+        destination = "/data"
+      }
+
+      resources {
+        cpu    = 256
+        memory = 256
+      }
+    }
+
+    network {
+      mode = "host"
+      port "kutt" {
+        static = "3000"
+      }
+    }
+  }
+}

--- a/nomad/storage/volumes/kutt.hcl
+++ b/nomad/storage/volumes/kutt.hcl
@@ -1,0 +1,9 @@
+id = "kutt" # ID as seen in nomad
+name = "kutt" # Display name
+type = "csi"
+plugin_id = "rabbitseason-srv-nfs" # Needs to match the deployed plugin
+
+capability {
+  access_mode     = "multi-node-multi-writer"
+  attachment_mode = "file-system"
+}


### PR DESCRIPTION
## Summary

- Adds `nomad/apps/kutt/kutt.hcl` — kutt.it URL shortener job
- Adds `nomad/storage/volumes/kutt.hcl` — CSI NFS volume via `rabbitseason-srv-nfs`
- Updates `nomad/apps/README.md`

## Config notes

- Listens on port 3000 (static)
- Postgres at `postgres.service.home.consul`, database/user `kutt`
- SMTP via `postfix-andvari-smarthost.service.home.consul:25`, no auth
- Traefik hostname routing: `go.home.andvari.net` with `internal-only` middleware + Let's Encrypt TLS
- Secrets at `nomad/jobs/kutt`: `postgres_pass`, `jwt_secret`
- Volume mounted at `/data`

## Pre-deploy checklist

- [x] Create postgres database and user: `CREATE USER kutt WITH PASSWORD '...'; CREATE DATABASE kutt OWNER kutt;`
- [ ] Create Nomad variable `nomad/jobs/kutt` with keys `postgres_pass` and `jwt_secret`
- [ ] Register the CSI volume: `nomad volume create nomad/storage/volumes/kutt.hcl`
- [ ] Add DNS record for `go.home.andvari.net`

🤖 Generated with [Claude Code](https://claude.com/claude-code)