### PR TITLE
feat: add pg-connect.sh script

### DIFF
--- a/scripts/pg-connect.sh
+++ b/scripts/pg-connect.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# pg-connect.sh — retrieve the postgres admin password from Nomad and open a psql shell.
+#
+# Fetches the password from the Nomad variable at nomad/jobs/postgres and connects
+# to postgres.service.home.consul as the postgres superuser.
+#
+# Requires: nomad CLI, psql, jq
+# Requires: NOMAD_TOKEN set in environment
+# Optional: NOMAD_ADDR (default: http://127.0.0.1:4646)
+set -euo pipefail
+
+if [[ -z "${NOMAD_TOKEN:-}" ]]; then
+    echo "ERROR: NOMAD_TOKEN is not set" >&2
+    exit 1
+fi
+
+PGPASSWORD=$(nomad var get -out=json nomad/jobs/postgres | jq -r '.Items.pgpassword')
+export PGPASSWORD
+
+exec psql -h postgres.service.home.consul -U postgres "$@"


### PR DESCRIPTION
## Summary

- Adds `scripts/pg-connect.sh` — fetches the postgres superuser password from the Nomad variable at `nomad/jobs/postgres` and execs `psql` against `postgres.service.home.consul`

## Usage

```sh
export NOMAD_TOKEN=...
bash scripts/pg-connect.sh            # opens psql shell as postgres
bash scripts/pg-connect.sh -c '\l'   # pass psql args directly
```

Requires `nomad`, `psql`, and `jq` on `$PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)