### PR TITLE
feat: add Grafana at home.andvari.net/graphs

### DIFF
--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -1,0 +1,276 @@
+# Grafana
+
+Grafana is deployed at `https://home.andvari.net/graphs/`. It uses PostgreSQL
+for its database (no SQLite) and reads all provisioning config (datasources,
+dashboard definitions) from the `gitrepo` CSI volume, so the full state of
+dashboards is in version control.
+
+## Architecture
+
+```
+GitHub push
+  → homelab-webhook (port 9111)
+      → git pull on gitrepo CSI volume
+      → if monitoring/grafana/ changed:
+          → POST /api/admin/provisioning/datasources/reload  (Grafana)
+          → POST /api/admin/provisioning/dashboards/reload   (Grafana)
+
+Grafana container
+  → reads provisioning from /config/monitoring/grafana/provisioning/
+     (gitrepo CSI volume, path monitoring/grafana/provisioning/)
+  → polls /config/monitoring/grafana/dashboards/ every 30s for dashboard JSON
+  → persists plugins and session state to grafana CSI volume (rabbitseason-srv-nfs)
+  → stores all other state in PostgreSQL (postgres.service.home.consul:5432)
+
+Traefik
+  → routes home.andvari.net/graphs → grafana.service.home.consul:3000
+  → internal-only middleware (192.168.100.0/24)
+```
+
+## First-time setup
+
+### 1. Create the Postgres database
+
+Connect as the postgres superuser and create the `grafana` role and database:
+
+```bash
+bash scripts/pg-connect.sh
+```
+
+```sql
+CREATE USER grafana WITH PASSWORD 'choose-a-password';
+CREATE DATABASE grafana OWNER grafana;
+\q
+```
+
+### 2. Create the CSI volume
+
+```bash
+nomad volume create nomad/storage/volumes/grafana.hcl
+```
+
+### 3. Set Nomad variables for Grafana
+
+```bash
+nomad var put nomad/jobs/grafana \
+  grafana_admin_user=admin \
+  grafana_admin_password=<strong-password> \
+  grafana_db_password=<postgres-grafana-password>
+```
+
+| Key                    | Description                                |
+|------------------------|--------------------------------------------|
+| `grafana_admin_user`   | Initial admin username                     |
+| `grafana_admin_password` | Initial admin password                   |
+| `grafana_db_password`  | Password for the `grafana` Postgres user   |
+
+### 4. Update homelab-webhook variables
+
+The webhook server needs the Grafana admin credentials to call the provisioning
+reload API. Add them to the existing variable:
+
+```bash
+nomad var put nomad/jobs/homelab-webhook \
+  github_webhook_secret=<existing-secret> \
+  grafana_admin_user=admin \
+  grafana_admin_password=<same-as-above> \
+  nomad_token=<existing-token-if-any>
+```
+
+### 5. Deploy
+
+```bash
+nomad job run nomad/monitoring/grafana.hcl
+nomad job run nomad/infra/traefik/traefik.hcl
+nomad job run nomad/infra/homelab-webhook/homelab-webhook.hcl
+```
+
+### 6. Verify
+
+```bash
+# Check the job is running
+nomad job status grafana
+
+# Check Grafana is healthy
+curl -s http://grafana.service.home.consul:3000/graphs/api/health
+
+# Check Traefik can route to it
+curl -sk https://home.andvari.net/graphs/api/health
+```
+
+---
+
+## Adding dashboards
+
+Dashboards are JSON files under `monitoring/grafana/dashboards/`. Grafana polls
+this directory every 30 seconds (via `updateIntervalSeconds: 30` in the
+dashboard provider). A webhook push to `main` also triggers an immediate reload.
+
+### Workflow: design in the UI, save to git
+
+1. Open `https://home.andvari.net/graphs/` and build the dashboard in the Grafana UI.
+2. Once happy, export it: **Dashboard menu → Share → Export → Save to file**.
+3. Save the JSON file to `monitoring/grafana/dashboards/<name>.json`.
+4. Commit and push. The webhook will reload Grafana within seconds.
+
+> Dashboard JSON exported from Grafana contains a `uid` field. Keep this stable
+> across edits — Grafana uses it to match the file to the existing dashboard.
+> If you delete the `uid`, Grafana will create a duplicate on next reload.
+
+### Subdirectories as folders
+
+If `foldersFromFilesStructure: true` is set (it is), subdirectories under
+`monitoring/grafana/dashboards/` become Grafana folders:
+
+```
+monitoring/grafana/dashboards/
+  nodes/
+    cpu.json       → folder "nodes"
+    memory.json    → folder "nodes"
+  services/
+    nomad.json     → folder "services"
+```
+
+### Removing a dashboard
+
+Delete the JSON file and push. Grafana will remove the dashboard on the next
+poll (since `disableDeletion: false`).
+
+---
+
+## Adding datasources
+
+Datasource definitions live in
+`monitoring/grafana/provisioning/datasources/*.yaml`. The Prometheus datasource
+is pre-configured. To add another:
+
+1. Create a new YAML file following the
+   [Grafana datasource provisioning schema](https://grafana.com/docs/grafana/latest/administration/provisioning/#data-sources).
+2. Commit and push. The webhook calls
+   `POST /api/admin/provisioning/datasources/reload` automatically.
+
+To reload manually without a push:
+
+```bash
+curl -s -X POST -u admin:PASSWORD \
+  http://grafana.service.home.consul:3000/api/admin/provisioning/datasources/reload
+```
+
+---
+
+## Playbook
+
+### Check what Grafana is doing
+
+```bash
+# Job status
+nomad job status grafana
+
+# Live logs
+nomad alloc logs -job grafana -f grafana_server
+
+# Health endpoint
+curl -s http://grafana.service.home.consul:3000/graphs/api/health
+
+# List provisioned datasources
+curl -s -u admin:PASSWORD \
+  http://grafana.service.home.consul:3000/api/datasources | jq '.[].name'
+
+# List provisioned dashboards
+curl -s -u admin:PASSWORD \
+  http://grafana.service.home.consul:3000/api/search | jq '.[].title'
+```
+
+### Manually trigger provisioning reload
+
+```bash
+GRAFANA=http://grafana.service.home.consul:3000
+CREDS=admin:PASSWORD
+
+curl -s -X POST -u "$CREDS" "$GRAFANA/api/admin/provisioning/datasources/reload"
+curl -s -X POST -u "$CREDS" "$GRAFANA/api/admin/provisioning/dashboards/reload"
+```
+
+### Reset admin password
+
+If the admin password is lost or needs rotating:
+
+```bash
+# Option 1: via Grafana CLI inside the container
+nomad alloc exec -job grafana grafana_server \
+  grafana-cli admin reset-admin-password NEW_PASSWORD
+
+# Option 2: update the Nomad variable and redeploy
+nomad var put nomad/jobs/grafana \
+  grafana_admin_user=admin \
+  grafana_admin_password=NEW_PASSWORD \
+  grafana_db_password=<existing-db-password>
+nomad job run nomad/monitoring/grafana.hcl
+```
+
+After rotating the password, also update `nomad/jobs/homelab-webhook`:
+
+```bash
+nomad var put nomad/jobs/homelab-webhook \
+  github_webhook_secret=<existing> \
+  grafana_admin_user=admin \
+  grafana_admin_password=NEW_PASSWORD \
+  nomad_token=<existing-if-any>
+# Redeploy webhook to pick up the new env var
+nomad job run nomad/infra/homelab-webhook/homelab-webhook.hcl
+```
+
+### Upgrade Grafana
+
+1. Update the image tag in `nomad/monitoring/grafana.hcl`.
+2. Commit, push, and redeploy:
+
+```bash
+nomad job run nomad/monitoring/grafana.hcl
+```
+
+Grafana will run any database migrations automatically on startup. The
+PostgreSQL backend ensures no data is lost during upgrades.
+
+### Inspect the database
+
+```bash
+bash scripts/pg-connect.sh
+\c grafana
+\dt                      -- list tables
+SELECT title FROM dashboard;
+SELECT name FROM data_source;
+```
+
+### Restore from backup
+
+Grafana's state is in the `grafana` Postgres database, backed up daily by the
+`pgbackup` sidecar. Follow the restore procedure in
+`nomad/infra/postgres/README.md`, restoring the `grafana` database.
+
+After restoring, restart the Grafana job to clear any in-memory cache:
+
+```bash
+nomad job run nomad/monitoring/grafana.hcl
+```
+
+---
+
+## Next steps
+
+- **Add dashboards**: Start with node_exporter metrics — the recording rules in
+  `monitoring/node_exporter_recording_rules.yml` pre-compute CPU, memory, disk
+  I/O, and network metrics ready for use. Export from the UI and commit.
+
+- **Alerting**: Grafana can also send alerts. For now, alerting is handled by
+  Alertmanager — evaluate whether to consolidate or keep them separate.
+
+- **Grafana plugins**: Add plugin IDs to `GF_INSTALL_PLUGINS` in `grafana.hcl`
+  (e.g. `GF_INSTALL_PLUGINS=grafana-piechart-panel`). They download at startup
+  and persist to the `grafana` CSI volume.
+
+- **Additional datasources**: Loki for log aggregation, if added later, just
+  needs a file in `monitoring/grafana/provisioning/datasources/`.
+
+- **Organisation/teams**: Grafana supports multiple orgs and teams. For a
+  single-user homelab the default org is fine.

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -3,7 +3,7 @@
 Prometheus configuration files, mounted into the prometheus container via the
 `gitrepo` CSI volume by the Nomad job in `nomad/monitoring/prometheus.hcl`.
 
-| File | Purpose |
+| File / Directory | Purpose |
 |---|---|
 | `prometheus.yml` | Main config: scrape jobs, alertmanager address, rule files |
 | `node_exporter_alerting_rules.yml` | Alerts for host-level metrics (disk, memory, load) |
@@ -11,19 +11,31 @@ Prometheus configuration files, mounted into the prometheus container via the
 | `blackbox_alerting_rules.yml` | Alerts for failed HTTP/ICMP probes |
 | `prom-alertmanager.yml` | Alert routing and email notification config |
 | `prom-blackbox-exporter.yml` | Probe module definitions (http_2xx, icmp) |
+| `grafana/` | Grafana provisioning config and dashboard JSON files |
+| `grafana/provisioning/datasources/` | Datasource definitions (Prometheus pre-configured) |
+| `grafana/provisioning/dashboards/` | Dashboard provider config |
+| `grafana/dashboards/` | Dashboard JSON files — add `.json` exports here |
+
+See `docs/grafana.md` for the Grafana setup guide and playbook.
 
 ## Config reload workflow
 
 Config changes are applied by pushing to `main`. A GitHub webhook triggers
 `homelab-webhook` (a Nomad service job at `nomad/infra/homelab-webhook/`),
-which pulls the latest git repo onto the `gitrepo` CSI volume and POSTs
-`/-/reload` to prometheus, alertmanager, and blackbox-exporter.
+which pulls the latest git repo onto the `gitrepo` CSI volume.
 
 ```
-git push → GitHub webhook → hooks.andvari.net (Traefik)
+git push → GitHub webhook → home.andvari.net/webhooks/monitoring-reload (Traefik)
   → homelab-webhook Nomad job → git pull on CSI volume
-  → POST /-/reload to prometheus, alertmanager, blackbox-exporter
+  → if monitoring/ changed (excl. grafana/):
+      POST /-/reload to prometheus, alertmanager, blackbox-exporter
+  → if monitoring/grafana/ changed:
+      POST /api/admin/provisioning/datasources/reload to Grafana
+      POST /api/admin/provisioning/dashboards/reload to Grafana
 ```
+
+Grafana also polls `monitoring/grafana/dashboards/` every 30 seconds, so
+dashboard JSON changes propagate even without a webhook push.
 
 ## Validating configs before pushing
 

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yaml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: homelab
+    folder: Homelab
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 30
+    options:
+      path: /config/monitoring/grafana/dashboards
+      foldersFromFilesStructure: true

--- a/monitoring/grafana/provisioning/datasources/prometheus.yaml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus.service.home.consul:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: "15s"

--- a/nomad/infra/homelab-webhook/README.md
+++ b/nomad/infra/homelab-webhook/README.md
@@ -13,7 +13,11 @@ A lightweight Python webhook server (`webhook.py`) that watches for changes to
 `monitoring/` files. On a matching push to `main`:
 
 1. Runs `git pull` on the `gitrepo` CSI volume (shared read-write mount).
-2. POSTs `/-/reload` to Prometheus, Alertmanager, and Blackbox Exporter.
+2. If any `monitoring/` files changed (excluding `monitoring/grafana/`): POSTs
+   `/-/reload` to Prometheus, Alertmanager, and Blackbox Exporter.
+3. If any `monitoring/grafana/` files changed: POSTs the Grafana provisioning
+   reload API (`/api/admin/provisioning/datasources/reload` and
+   `/api/admin/provisioning/dashboards/reload`) using Basic auth.
 
 Listens on port **9111**. Traefik routes `POST /webhooks/monitoring-reload` to
 this service.
@@ -49,13 +53,17 @@ variable before deploying:
 ```bash
 nomad var put nomad/jobs/homelab-webhook \
   github_webhook_secret=<secret> \
+  grafana_admin_user=<grafana-admin-username> \
+  grafana_admin_password=<grafana-admin-password> \
   nomad_token=<optional-acl-token>
 ```
 
-| Key                    | Required | Description                                              |
-|------------------------|----------|----------------------------------------------------------|
-| `github_webhook_secret` | yes     | HMAC secret configured in the GitHub webhook settings    |
-| `nomad_token`           | no      | Nomad ACL token for nomad-botherer (omit if ACL disabled) — see `nomad/acl/` |
+| Key                      | Required | Description                                              |
+|--------------------------|----------|----------------------------------------------------------|
+| `github_webhook_secret`  | yes      | HMAC secret configured in the GitHub webhook settings    |
+| `grafana_admin_user`     | yes      | Grafana admin username (must match `nomad/jobs/grafana`) |
+| `grafana_admin_password` | yes      | Grafana admin password (must match `nomad/jobs/grafana`) |
+| `nomad_token`            | no       | Nomad ACL token for nomad-botherer (omit if ACL disabled) — see `nomad/acl/` |
 
 ---
 

--- a/nomad/infra/homelab-webhook/homelab-webhook.hcl
+++ b/nomad/infra/homelab-webhook/homelab-webhook.hcl
@@ -40,6 +40,8 @@ job "homelab-webhook" {
         env         = true
         data        = <<EOF
 GITHUB_WEBHOOK_SECRET={{ with nomadVar "nomad/jobs/homelab-webhook" }}{{ .github_webhook_secret }}{{ end }}
+GRAFANA_ADMIN_USER={{ with nomadVar "nomad/jobs/homelab-webhook" }}{{ .grafana_admin_user }}{{ end }}
+GRAFANA_ADMIN_PASSWORD={{ with nomadVar "nomad/jobs/homelab-webhook" }}{{ .grafana_admin_password }}{{ end }}
 EOF
       }
 

--- a/nomad/infra/homelab-webhook/webhook.py
+++ b/nomad/infra/homelab-webhook/webhook.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import base64
 import datetime
 import hashlib
 import hmac
@@ -20,6 +21,14 @@ RELOAD_TARGETS = [
     "http://prometheus.service.home.consul:9090/-/reload",
     "http://prom-alertmanager.service.home.consul:9093/-/reload",
     "http://prom-blackbox-exporter.service.home.consul:9115/-/reload",
+]
+
+GRAFANA_ADMIN_USER = os.environ.get("GRAFANA_ADMIN_USER", "admin")
+GRAFANA_ADMIN_PASSWORD = os.environ.get("GRAFANA_ADMIN_PASSWORD", "")
+
+GRAFANA_RELOAD_TARGETS = [
+    "http://grafana.service.home.consul:3000/api/admin/provisioning/datasources/reload",
+    "http://grafana.service.home.consul:3000/api/admin/provisioning/dashboards/reload",
 ]
 
 
@@ -48,16 +57,32 @@ def git_pull():
 
 
 def touches_monitoring(payload):
+    """Returns True if any prometheus/alertmanager/blackbox config files changed."""
     changed = []
     for commit in payload.get("commits", []):
         for key in ("added", "removed", "modified"):
             for path in commit.get(key, []):
-                if path.startswith("monitoring/"):
+                if path.startswith("monitoring/") and not path.startswith("monitoring/grafana/"):
                     changed.append(f"{key}: {path}")
     if changed:
         log(f"Monitoring files changed ({len(changed)}): {', '.join(changed)}")
     else:
-        log("No monitoring/ files changed — skipping reload")
+        log("No prometheus/alertmanager/blackbox files changed — skipping prometheus reload")
+    return bool(changed)
+
+
+def touches_grafana_config(payload):
+    """Returns True if any Grafana provisioning files changed."""
+    changed = []
+    for commit in payload.get("commits", []):
+        for key in ("added", "removed", "modified"):
+            for path in commit.get(key, []):
+                if path.startswith("monitoring/grafana/"):
+                    changed.append(f"{key}: {path}")
+    if changed:
+        log(f"Grafana config files changed ({len(changed)}): {', '.join(changed)}")
+    else:
+        log("No monitoring/grafana/ files changed — skipping grafana reload")
     return bool(changed)
 
 
@@ -72,6 +97,25 @@ def reload_services():
                 log(f"  -> OK (HTTP {resp.status})")
         except Exception as e:
             raise RuntimeError(f"Reload failed for {url}: {e}")
+
+
+def reload_grafana():
+    if not GRAFANA_ADMIN_PASSWORD:
+        raise RuntimeError("GRAFANA_ADMIN_PASSWORD not set — cannot reload Grafana provisioning")
+    credentials = base64.b64encode(
+        f"{GRAFANA_ADMIN_USER}:{GRAFANA_ADMIN_PASSWORD}".encode()
+    ).decode()
+    for url in GRAFANA_RELOAD_TARGETS:
+        log(f"Sending POST to {url}")
+        req = urllib.request.Request(url, method="POST", data=b"")
+        req.add_header("Authorization", f"Basic {credentials}")
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                if resp.status not in (200, 204):
+                    raise RuntimeError(f"HTTP {resp.status}")
+                log(f"  -> OK (HTTP {resp.status})")
+        except Exception as e:
+            raise RuntimeError(f"Grafana reload failed for {url}: {e}")
 
 
 class WebhookHandler(http.server.BaseHTTPRequestHandler):
@@ -155,9 +199,13 @@ class WebhookHandler(http.server.BaseHTTPRequestHandler):
         try:
             git_pull()
             if touches_monitoring(payload):
-                log("Triggering reload of monitoring services")
+                log("Triggering reload of prometheus/alertmanager/blackbox")
                 reload_services()
-                log("All monitoring service reloads complete")
+                log("All prometheus service reloads complete")
+            if touches_grafana_config(payload):
+                log("Triggering reload of Grafana provisioning")
+                reload_grafana()
+                log("Grafana provisioning reload complete")
             self.send_response(200)
             self.end_headers()
             self.wfile.write(b"OK")

--- a/nomad/infra/traefik/traefik.hcl
+++ b/nomad/infra/traefik/traefik.hcl
@@ -165,6 +165,12 @@ http:
       tls:
         certResolver: le
       service: nomad-botherer
+    grafana:
+      rule: "Host(`home.andvari.net`) && PathPrefix(`/graphs`)"
+      tls:
+        certResolver: le
+      middlewares: [internal-only]
+      service: grafana
 
   services:
     # Consul DNS resolves these to wherever the service is currently running.
@@ -188,6 +194,10 @@ http:
       loadBalancer:
         servers:
           - url: "http://nomad-botherer.service.home.consul:9112"
+    grafana:
+      loadBalancer:
+        servers:
+          - url: "http://grafana.service.home.consul:3000"
 EOH
         destination = "local/dynamic.yml"
       }

--- a/nomad/monitoring/README.md
+++ b/nomad/monitoring/README.md
@@ -1,6 +1,6 @@
 # nomad/monitoring
 
-Prometheus-based monitoring stack.
+Prometheus-based monitoring stack with Grafana dashboards.
 
 | Job | What it is |
 |---|---|
@@ -8,10 +8,15 @@ Prometheus-based monitoring stack.
 | `prom-alertmanager` | Alert routing (email notifications) |
 | `prom-blackbox-exporter` | HTTP and ICMP probes |
 | `prom-consul-exporter` | Consul cluster metrics |
+| `grafana` | Dashboards and visualisation at `home.andvari.net/graphs` |
 
 Prometheus config files (scrape targets, alert rules, recording rules) live in
 `monitoring/` at the repo root — mounted into the prometheus container via the
 `gitrepo` CSI volume.
+
+Grafana provisioning config (datasources, dashboard providers, dashboard JSON
+files) lives in `monitoring/grafana/` — also mounted via the `gitrepo` CSI
+volume. See `docs/grafana.md` for the full setup guide and playbook.
 
 To reload Prometheus config without restarting the container:
 
@@ -19,3 +24,17 @@ To reload Prometheus config without restarting the container:
 bash scripts/reload_prometheus.sh
 bash scripts/reload_prometheus_blackbox.sh  # for blackbox exporter
 ```
+
+To reload Grafana provisioning (datasources + dashboards) without restarting:
+
+```bash
+# Requires admin credentials
+curl -s -X POST -u admin:PASSWORD \
+  http://grafana.service.home.consul:3000/api/admin/provisioning/datasources/reload
+curl -s -X POST -u admin:PASSWORD \
+  http://grafana.service.home.consul:3000/api/admin/provisioning/dashboards/reload
+```
+
+Grafana also polls `monitoring/grafana/dashboards/` every 30 seconds for
+updated dashboard JSON files, so dashboard changes propagate automatically
+without needing a webhook push.

--- a/nomad/monitoring/grafana.hcl
+++ b/nomad/monitoring/grafana.hcl
@@ -1,0 +1,87 @@
+job "grafana" {
+  datacenters = ["home"]
+
+  group "grafana_servers" {
+
+    volume "grafana" {
+      type            = "csi"
+      source          = "grafana"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
+    volume "gitrepo" {
+      type            = "csi"
+      source          = "gitrepo"
+      read_only       = true
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
+    network {
+      port "grafana" {
+        static = 3000
+      }
+    }
+
+    task "grafana_server" {
+      driver = "docker"
+
+      # Grafana configuration via environment variables.
+      # grafana_admin_user / grafana_admin_password: initial admin credentials.
+      # grafana_db_password: password for the 'grafana' Postgres user.
+      # Database must be created before first deploy — see docs/grafana.md.
+      template {
+        destination = "secrets/grafana.env"
+        env         = true
+        data        = <<EOH
+GF_SECURITY_ADMIN_USER={{ with nomadVar "nomad/jobs/grafana" }}{{ .grafana_admin_user }}{{ end }}
+GF_SECURITY_ADMIN_PASSWORD={{ with nomadVar "nomad/jobs/grafana" }}{{ .grafana_admin_password }}{{ end }}
+GF_DATABASE_TYPE=postgres
+GF_DATABASE_HOST=postgres.service.home.consul:5432
+GF_DATABASE_NAME=grafana
+GF_DATABASE_USER=grafana
+GF_DATABASE_PASSWORD={{ with nomadVar "nomad/jobs/grafana" }}{{ .grafana_db_password }}{{ end }}
+GF_DATABASE_SSL_MODE=disable
+GF_SERVER_ROOT_URL=https://home.andvari.net/graphs/
+GF_SERVER_SERVE_FROM_SUB_PATH=true
+GF_PATHS_PROVISIONING=/config/monitoring/grafana/provisioning
+GF_AUTH_ANONYMOUS_ENABLED=false
+EOH
+      }
+
+      config {
+        image = "grafana/grafana:11.4.0"
+        ports = ["grafana"]
+        dns_search_domains = ["home.andvari.net"]
+      }
+
+      volume_mount {
+        volume      = "grafana"
+        destination = "/var/lib/grafana"
+      }
+
+      volume_mount {
+        volume      = "gitrepo"
+        destination = "/config"
+      }
+
+      service {
+        name = "grafana"
+        port = "grafana"
+        check {
+          type     = "http"
+          path     = "/graphs/api/health"
+          interval = "10s"
+          timeout  = "5s"
+        }
+      }
+
+      resources {
+        cpu    = 500
+        memory = 512
+      }
+    }
+  }
+}

--- a/nomad/storage/volumes/grafana.hcl
+++ b/nomad/storage/volumes/grafana.hcl
@@ -1,0 +1,9 @@
+id        = "grafana"
+name      = "grafana"
+type      = "csi"
+plugin_id = "rabbitseason-srv-nfs"
+
+capability {
+  access_mode     = "multi-node-multi-writer"
+  attachment_mode = "file-system"
+}


### PR DESCRIPTION
## Summary

- Adds Grafana 11.4.0 as a Nomad job at `home.andvari.net/graphs` (internal-only, TLS via Traefik)
- PostgreSQL backend — no SQLite; all state in the existing Postgres instance
- Dashboard definitions and datasource config live in `monitoring/grafana/` (gitrepo CSI volume), provisioned automatically on startup and reloaded on push
- New CSI volume (`grafana`) on `rabbitseason-srv-nfs` for `/var/lib/grafana` (plugin cache etc.)
- Extends `homelab-webhook` to detect `monitoring/grafana/` changes and POST to Grafana's provisioning reload API, separate from the existing prometheus/alertmanager/blackbox reload

## Before deploying (see `docs/grafana.md`)

- [ ] Create `grafana` Postgres user and database (`bash scripts/pg-connect.sh`)
- [ ] `nomad volume create nomad/storage/volumes/grafana.hcl`
- [ ] `nomad var put nomad/jobs/grafana grafana_admin_user=... grafana_admin_password=... grafana_db_password=...`
- [ ] Add `grafana_admin_user` + `grafana_admin_password` to `nomad/jobs/homelab-webhook`
- [ ] `nomad job run nomad/monitoring/grafana.hcl`
- [ ] `nomad job run nomad/infra/traefik/traefik.hcl`
- [ ] `nomad job run nomad/infra/homelab-webhook/homelab-webhook.hcl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)