### PR TITLE
feat: deploy node_exporter to all hosts and add Grafana dashboards

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -93,6 +93,16 @@ nomadconsul:
                   - "192.168.100.250"
                   - "192.168.100.253"
 
+# All physical hosts that should run node_exporter.
+# tings is scraped by prometheus but is not managed by ansible -- install
+# node_exporter there manually (see ansible/roles/node_exporter/README.md).
+node_exporter:
+        children:
+                nomadconsul:
+        hosts:
+                rabbitseason:
+                        ansible_user: doc
+
 # Machines with a localy connected UPS.
 ups:
         hosts:

--- a/ansible/roles/node_exporter/README.md
+++ b/ansible/roles/node_exporter/README.md
@@ -1,0 +1,24 @@
+# node_exporter role
+
+Installs `prometheus-node-exporter` from the distro's apt repository and
+ensures the service is enabled and running. The exporter listens on port 9100.
+
+All physical hosts are Debian/Ubuntu-based so the apt package is the simplest
+approach — no binary downloads or architecture detection needed.
+
+## Hosts not managed by Ansible
+
+`tings` is scraped by Prometheus but is not in the Ansible inventory. To
+install node_exporter there manually:
+
+```bash
+sudo apt-get update && sudo apt-get install -y prometheus-node-exporter
+sudo systemctl enable --now prometheus-node-exporter
+```
+
+## Running the playbook
+
+```bash
+cd ansible
+ansible-playbook -i inventory.yml site.yml --limit node_exporter
+```

--- a/ansible/roles/node_exporter/meta/main.yml
+++ b/ansible/roles/node_exporter/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/ansible/roles/node_exporter/tasks/main.yml
+++ b/ansible/roles/node_exporter/tasks/main.yml
@@ -1,0 +1,12 @@
+- name: Install prometheus-node-exporter
+  ansible.builtin.apt:
+    update_cache: yes
+    cache_valid_time: 3600
+    pkg:
+      - prometheus-node-exporter
+
+- name: Enable and start prometheus-node-exporter
+  ansible.builtin.systemd:
+    name: prometheus-node-exporter
+    enabled: yes
+    state: started

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -37,3 +37,11 @@
   become_user: root
   roles:
     - role: ups
+
+- name: all physical hosts
+  hosts: node_exporter
+  any_errors_fatal: false
+  become: true
+  become_user: root
+  roles:
+    - role: node_exporter

--- a/monitoring/grafana/dashboards/network-overview.json
+++ b/monitoring/grafana/dashboards/network-overview.json
@@ -1,0 +1,157 @@
+{
+  "title": "Network Overview",
+  "uid": "network-overview",
+  "tags": ["network", "nodes", "node-exporter"],
+  "schemaVersion": 40,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-3h", "to": "now" },
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "id": 1,
+      "title": "Network Receive — all hosts",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "instance:node_network_receive_bytes_excluding_lo:rate1m{job=\"node_exporter\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "binBps",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max"] }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Network Transmit — all hosts",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 9 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "instance:node_network_transmit_bytes_excluding_lo:rate1m{job=\"node_exporter\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "binBps",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max"] }
+      }
+    },
+    {
+      "id": 3,
+      "title": "CPU Utilization — all hosts",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "instance:node_cpu_utilisation:rate1m{job=\"node_exporter\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max"] }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Memory Utilization — all hosts",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "instance:node_memory_utilisation:ratio{job=\"node_exporter\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max"] }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Network Drops — all hosts",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 27 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "instance:node_network_receive_drop_excluding_lo:rate1m{job=\"node_exporter\"}",
+          "legendFormat": "rx drop {{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "instance:node_network_transmit_drop_excluding_lo:rate1m{job=\"node_exporter\"}",
+          "legendFormat": "tx drop {{instance}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "pps",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/node-overview.json
+++ b/monitoring/grafana/dashboards/node-overview.json
@@ -1,0 +1,287 @@
+{
+  "title": "Node Overview",
+  "uid": "node-overview",
+  "tags": ["nodes", "node-exporter"],
+  "schemaVersion": 40,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-3h", "to": "now" },
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "label": "Host",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": "label_values(node_uname_info{job=\"node_exporter\"}, instance)",
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": false,
+        "multi": false,
+        "current": {}
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "CPU Utilization",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "instance:node_cpu_utilisation:rate1m{job=\"node_exporter\", instance=~\"$instance\"}",
+          "legendFormat": "cpu used",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Load per CPU",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "instance:node_load1_per_cpu:ratio{job=\"node_exporter\", instance=~\"$instance\"}",
+          "legendFormat": "load1 / cpu",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "node_load5{job=\"node_exporter\", instance=~\"$instance\"} / instance:node_num_cpu:sum{job=\"node_exporter\", instance=~\"$instance\"}",
+          "legendFormat": "load5 / cpu",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "node_load15{job=\"node_exporter\", instance=~\"$instance\"} / instance:node_num_cpu:sum{job=\"node_exporter\", instance=~\"$instance\"}",
+          "legendFormat": "load15 / cpu",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Memory Utilization",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "instance:node_memory_utilisation:ratio{job=\"node_exporter\", instance=~\"$instance\"}",
+          "legendFormat": "used",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Memory Breakdown",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "node_memory_MemTotal_bytes{job=\"node_exporter\", instance=~\"$instance\"}",
+          "legendFormat": "total",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "node_memory_MemAvailable_bytes{job=\"node_exporter\", instance=~\"$instance\"}",
+          "legendFormat": "available",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "node_memory_Cached_bytes{job=\"node_exporter\", instance=~\"$instance\"} + node_memory_Buffers_bytes{job=\"node_exporter\", instance=~\"$instance\"}",
+          "legendFormat": "cached+buffered",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Disk IO Busy",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "instance_device:node_disk_io_time_seconds:rate1m{job=\"node_exporter\", instance=~\"$instance\", device!~\"loop.*\"}",
+          "legendFormat": "{{device}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Filesystem Used",
+      "type": "bargauge",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "1 - node_filesystem_avail_bytes{job=\"node_exporter\", instance=~\"$instance\", fstype!~\"tmpfs|devtmpfs|overlay|squashfs\", mountpoint!~\"/run.*|/sys.*|/proc.*|/dev.*|/snap.*\"} / node_filesystem_size_bytes{job=\"node_exporter\", instance=~\"$instance\", fstype!~\"tmpfs|devtmpfs|overlay|squashfs\", mountpoint!~\"/run.*|/sys.*|/proc.*|/dev.*|/snap.*\"}",
+          "legendFormat": "{{mountpoint}}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.75 },
+              { "color": "red", "value": 0.90 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "displayMode": "gradient",
+        "showUnfilled": true
+      }
+    },
+    {
+      "id": 7,
+      "title": "Network Receive",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "instance:node_network_receive_bytes_excluding_lo:rate1m{job=\"node_exporter\", instance=~\"$instance\"}",
+          "legendFormat": "rx",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "binBps",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    },
+    {
+      "id": 8,
+      "title": "Network Transmit",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "instance:node_network_transmit_bytes_excluding_lo:rate1m{job=\"node_exporter\", instance=~\"$instance\"}",
+          "legendFormat": "tx",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "binBps",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    }
+  ]
+}

--- a/monitoring/node_exporter_recording_rules.yml
+++ b/monitoring/node_exporter_recording_rules.yml
@@ -4,55 +4,55 @@
   - "expr": |
       count without (cpu) (
         count without (mode) (
-          node_cpu_seconds_total{job="node"}
+          node_cpu_seconds_total{job="node_exporter"}
         )
       )
     "record": "instance:node_num_cpu:sum"
   - "expr": |
       1 - avg without (cpu, mode) (
-        rate(node_cpu_seconds_total{job="node", mode="idle"}[1m])
+        rate(node_cpu_seconds_total{job="node_exporter", mode="idle"}[1m])
       )
     "record": "instance:node_cpu_utilisation:rate1m"
   - "expr": |
       (
-        node_load1{job="node"}
+        node_load1{job="node_exporter"}
       /
-        instance:node_num_cpu:sum{job="node"}
+        instance:node_num_cpu:sum{job="node_exporter"}
       )
     "record": "instance:node_load1_per_cpu:ratio"
   - "expr": |
       1 - (
-        node_memory_MemAvailable_bytes{job="node"}
+        node_memory_MemAvailable_bytes{job="node_exporter"}
       /
-        node_memory_MemTotal_bytes{job="node"}
+        node_memory_MemTotal_bytes{job="node_exporter"}
       )
     "record": "instance:node_memory_utilisation:ratio"
   - "expr": |
-      rate(node_vmstat_pgmajfault{job="node"}[1m])
+      rate(node_vmstat_pgmajfault{job="node_exporter"}[1m])
     "record": "instance:node_vmstat_pgmajfault:rate1m"
   - "expr": |
-      rate(node_disk_io_time_seconds_total{job="node", device!=""}[1m])
+      rate(node_disk_io_time_seconds_total{job="node_exporter", device!=""}[1m])
     "record": "instance_device:node_disk_io_time_seconds:rate1m"
   - "expr": |
-      rate(node_disk_io_time_weighted_seconds_total{job="node", device!=""}[1m])
+      rate(node_disk_io_time_weighted_seconds_total{job="node_exporter", device!=""}[1m])
     "record": "instance_device:node_disk_io_time_weighted_seconds:rate1m"
   - "expr": |
       sum without (device) (
-        rate(node_network_receive_bytes_total{job="node", device!="lo"}[1m])
+        rate(node_network_receive_bytes_total{job="node_exporter", device!="lo"}[1m])
       )
     "record": "instance:node_network_receive_bytes_excluding_lo:rate1m"
   - "expr": |
       sum without (device) (
-        rate(node_network_transmit_bytes_total{job="node", device!="lo"}[1m])
+        rate(node_network_transmit_bytes_total{job="node_exporter", device!="lo"}[1m])
       )
     "record": "instance:node_network_transmit_bytes_excluding_lo:rate1m"
   - "expr": |
       sum without (device) (
-        rate(node_network_receive_drop_total{job="node", device!="lo"}[1m])
+        rate(node_network_receive_drop_total{job="node_exporter", device!="lo"}[1m])
       )
     "record": "instance:node_network_receive_drop_excluding_lo:rate1m"
   - "expr": |
       sum without (device) (
-        rate(node_network_transmit_drop_total{job="node", device!="lo"}[1m])
+        rate(node_network_transmit_drop_total{job="node_exporter", device!="lo"}[1m])
       )
     "record": "instance:node_network_transmit_drop_excluding_lo:rate1m"

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -22,11 +22,11 @@ scrape_configs:
       - targets: ['localhost:9090']
 
   # Physical hosts -- node_exporter on port 9100.
-  # 1m interval: node metrics don't need to be fresher than this.
+  # 60s interval is sufficient resolution for host metrics.
   # Host list is anchored here and reused by blackbox-ping below.
   - job_name: node_exporter
-    scrape_interval: 1m
-    scrape_timeout: 1m
+    scrape_interval: 60s
+    scrape_timeout: 55s
     static_configs:
       - targets: &physical_hosts
           - hedwig


### PR DESCRIPTION
## Summary

- **Ansible**: new `node_exporter` role using `apt install prometheus-node-exporter` (Debian/Ubuntu package — no binary download needed). Adds an `node_exporter` inventory group (all `nomadconsul` nodes + `rabbitseason`). `tings` is documented as manual-install only since it's not in the inventory.
- **Recording rules fix**: `job="node"` → `job="node_exporter"` throughout `node_exporter_recording_rules.yml` — the rules were producing no output because the scrape job is named `node_exporter`, not `node`. This was a pre-existing bug now that we're adding dashboards that depend on these rules.
- **Two Grafana dashboards** (auto-provisioned via the `monitoring/grafana/dashboards/` file provider):
  - `node-overview`: per-host; `instance` dropdown variable; panels for CPU %, load/cpu, memory %, memory breakdown, disk IO busy, filesystem used (bar gauge with yellow/red thresholds), network RX, network TX
  - `network-overview`: fleet-wide; network RX/TX for all hosts, fleet CPU and memory utilisation, network drops

## Deploy order

```bash
# 1. Install node_exporter on all managed physical hosts
cd ansible
ansible-playbook -i inventory.yml site.yml --limit node_exporter

# 2. Push to main triggers homelab-webhook → prometheus reloads recording rules
# 3. Grafana polls monitoring/grafana/dashboards/ every 30s and picks up the new JSON
```

## Notes

- `tings` is not in the Ansible inventory; install manually: `apt install prometheus-node-exporter`
- The recording rules fix takes effect on the next prometheus reload (automatic on merge)
- Dashboard `instance` labels will show `hedwig:9100` etc. (port is added by prometheus relabelling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)