### PR TITLE
perf: skip apt repo setup when packages are already at correct version

### DIFF
--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -1,6 +1,9 @@
+- name: Gather package facts
+  ansible.builtin.package_facts:
+    manager: apt
+
 - name: Remove incompatible business.
   ansible.builtin.apt:
-    update-cache: yes
     state: absent
     pkg:
       - docker
@@ -8,35 +11,40 @@
       - docker.io
       - containerd
       - runc
+  when: "'docker-ce' not in ansible_facts.packages"
 
 - name: Install pre-requisites.
   ansible.builtin.apt:
-    update-cache: yes
+    update_cache: yes
+    cache_valid_time: 3600
     pkg:
       - apt-transport-https
       - ca-certificates
       - curl
       - gnupg
       - lsb-release
+  when: "'docker-ce' not in ansible_facts.packages"
 
 - name: Add Docker apt key
   ansible.builtin.apt_key:
     url: https://download.docker.com/linux/ubuntu/gpg
     state: present
+  when: "'docker-ce' not in ansible_facts.packages"
 
 - name: Add Docker stable repository.
   apt_repository:
     repo: "deb [arch={{ download_arch }}] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} stable"
     state: present
     update_cache: yes
+  when: "'docker-ce' not in ansible_facts.packages"
 
 - name: Install Docker.
   ansible.builtin.apt:
-    update-cache: yes
     pkg:
       - docker-ce
       - docker-ce-cli
       - containerd.io
+  when: "'docker-ce' not in ansible_facts.packages"
 
 - name: Deploy Docker daemon configuration.
   ansible.builtin.template:

--- a/ansible/roles/hashicorp/tasks/main.yml
+++ b/ansible/roles/hashicorp/tasks/main.yml
@@ -1,9 +1,22 @@
 # --- Hashicorp apt repo setup ---
 
+- name: Gather package facts
+  ansible.builtin.package_facts:
+    manager: apt
+
+- name: Set fact — hashicorp packages need installing or upgrading
+  ansible.builtin.set_fact:
+    hashicorp_needs_install: >-
+      {{ 'consul' not in ansible_facts.packages or
+         ansible_facts.packages['consul'][0].version != consul_version + '-1' or
+         'nomad' not in ansible_facts.packages or
+         ansible_facts.packages['nomad'][0].version != nomad_version + '-1' }}
+
 - name: Add Hashicorp apt signing key
   ansible.builtin.apt_key:
     url: https://apt.releases.hashicorp.com/gpg
     state: present
+  when: hashicorp_needs_install
 
 - name: Add Hashicorp apt repository
   ansible.builtin.apt_repository:
@@ -11,6 +24,7 @@
     state: present
     filename: hashicorp
     update_cache: yes
+  when: hashicorp_needs_install
 
 # --- Consul ---
 


### PR DESCRIPTION
## Summary

- **docker role**: gates the full setup block (conflicting package removal, pre-req install, apt key fetch, repo add, Docker install) on `docker-ce` not being present — eliminates a spurious `apt-get update` on every run
- **hashicorp role**: gathers package facts and skips the Hashicorp apt key fetch and repo add (which triggers `apt-get update`) when consul and nomad are both already at their pinned versions

Config and service tasks remain unconditional in both roles so config drift is still corrected on every run.

## Test plan

- [ ] Run against a node where Docker/consul/nomad are already installed — verify setup steps are skipped
- [ ] Run against a fresh node — verify full install still works end to end
- [ ] Change a config file and re-run — verify the service is still restarted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)