### PR TITLE
feat: add consul alert rules and overview dashboard

### DIFF
--- a/monitoring/consul_alerting_rules.yml
+++ b/monitoring/consul_alerting_rules.yml
@@ -1,0 +1,39 @@
+"groups":
+- "name": "consul"
+  "rules":
+  - "alert": "ConsulExporterDown"
+    "annotations":
+      "description": "The Consul exporter cannot reach the Consul API at {{ $labels.instance }}."
+      "summary": "Consul API is unreachable."
+    "expr": |
+      consul_up{job="consul"} == 0
+    "for": "2m"
+    "labels":
+      "severity": "critical"
+  - "alert": "ConsulRaftPeersLow"
+    "annotations":
+      "description": "Consul raft peer count is {{ $value }}. Cluster may have lost quorum."
+      "summary": "Consul raft peer count is low."
+    "expr": |
+      consul_raft_peers{job="consul"} < 2
+    "for": "1m"
+    "labels":
+      "severity": "critical"
+  - "alert": "ConsulMemberCountLow"
+    "annotations":
+      "description": "Consul LAN member count is {{ $value }}. Nodes may have left the cluster."
+      "summary": "Consul cluster member count has dropped."
+    "expr": |
+      consul_serf_lan_members{job="consul"} < 4
+    "for": "5m"
+    "labels":
+      "severity": "warning"
+  - "alert": "ConsulServiceCheckCritical"
+    "annotations":
+      "description": "Consul service {{ $labels.service_name }} (check: {{ $labels.check }}) on node {{ $labels.node }} has been critical for 5 minutes."
+      "summary": "Consul service health check is critical."
+    "expr": |
+      consul_health_service_status{job="consul", status="critical"} == 1
+    "for": "5m"
+    "labels":
+      "severity": "warning"

--- a/monitoring/grafana/dashboards/consul-overview.json
+++ b/monitoring/grafana/dashboards/consul-overview.json
@@ -1,0 +1,300 @@
+{
+  "title": "Consul Overview",
+  "uid": "consul-overview",
+  "tags": ["consul", "hashicorp"],
+  "schemaVersion": 40,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-3h", "to": "now" },
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "templating": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Consul API",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "consul_up{job=\"consul\"}",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "Down", "color": "red", "index": 0 },
+                "1": { "text": "Up", "color": "green", "index": 1 }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 2,
+      "title": "Raft Peers",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "consul_raft_peers{job=\"consul\"}",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 2 },
+              { "color": "green", "value": 3 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 3,
+      "title": "LAN Members",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "consul_serf_lan_members{job=\"consul\"}",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 4 },
+              { "color": "green", "value": 6 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 4,
+      "title": "Catalog Nodes",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "consul_catalog_nodes{job=\"consul\"}",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 5,
+      "title": "Registered Services",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "consul_catalog_services{job=\"consul\"}",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 6,
+      "title": "Service Health Checks",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(consul_health_service_status{job=\"consul\", status=\"passing\"})",
+          "legendFormat": "passing",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(consul_health_service_status{job=\"consul\", status=\"warning\"})",
+          "legendFormat": "warning",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(consul_health_service_status{job=\"consul\", status=\"critical\"})",
+          "legendFormat": "critical",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "passing" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "warning" }, "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "critical" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ]
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Critical Service Checks",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "consul_health_service_status{job=\"consul\", status=\"critical\"} == 1",
+          "legendFormat": "{{service_name}} / {{check}} @ {{node}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "color": { "fixedColor": "red", "mode": "fixed" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    },
+    {
+      "id": 8,
+      "title": "Cluster Membership",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "consul_raft_peers{job=\"consul\"}",
+          "legendFormat": "raft peers",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "consul_serf_lan_members{job=\"consul\"}",
+          "legendFormat": "LAN members",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    }
+  ]
+}

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -7,6 +7,7 @@ rule_files:
   - "node_exporter_recording_rules.yml"
   - "node_exporter_alerting_rules.yml"
   - "nomad_botherer_alerting_rules.yml"
+  - "consul_alerting_rules.yml"
 
 alerting:
   alertmanagers:


### PR DESCRIPTION
## Summary

- Adds `consul_alerting_rules.yml` with 4 alert rules covering API availability, raft quorum, cluster membership, and service health checks
- Adds `consul-overview.json` Grafana dashboard with stat panels, service health timeseries, and cluster membership trends
- Wires the new rules file into `prometheus.yml`

The consul exporter has been running and scraping since #59 but nothing was consuming the metrics.

## Alerts added

| Alert | Condition | Severity |
|---|---|---|
| `ConsulExporterDown` | `consul_up == 0` for 2m | critical |
| `ConsulRaftPeersLow` | raft peers < 2 for 1m | critical |
| `ConsulMemberCountLow` | LAN members < 4 for 5m | warning |
| `ConsulServiceCheckCritical` | any service check critical for 5m | warning |

## Test plan

- [ ] Confirm rules load cleanly after webhook triggers a prometheus reload (`promtool check rules` passes — validated in CI)
- [ ] Check Grafana picks up the new dashboard from the provisioned directory
- [ ] Verify stat panels show expected values for a healthy cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)