### PR TITLE
fix: use 5m rate windows in node_exporter recording rules

### DIFF
--- a/monitoring/node_exporter_recording_rules.yml
+++ b/monitoring/node_exporter_recording_rules.yml
@@ -10,7 +10,7 @@
     "record": "instance:node_num_cpu:sum"
   - "expr": |
       1 - avg without (cpu, mode) (
-        rate(node_cpu_seconds_total{job="node_exporter", mode="idle"}[1m])
+        rate(node_cpu_seconds_total{job="node_exporter", mode="idle"}[5m])
       )
     "record": "instance:node_cpu_utilisation:rate1m"
   - "expr": |
@@ -28,31 +28,31 @@
       )
     "record": "instance:node_memory_utilisation:ratio"
   - "expr": |
-      rate(node_vmstat_pgmajfault{job="node_exporter"}[1m])
+      rate(node_vmstat_pgmajfault{job="node_exporter"}[5m])
     "record": "instance:node_vmstat_pgmajfault:rate1m"
   - "expr": |
-      rate(node_disk_io_time_seconds_total{job="node_exporter", device!=""}[1m])
+      rate(node_disk_io_time_seconds_total{job="node_exporter", device!=""}[5m])
     "record": "instance_device:node_disk_io_time_seconds:rate1m"
   - "expr": |
-      rate(node_disk_io_time_weighted_seconds_total{job="node_exporter", device!=""}[1m])
+      rate(node_disk_io_time_weighted_seconds_total{job="node_exporter", device!=""}[5m])
     "record": "instance_device:node_disk_io_time_weighted_seconds:rate1m"
   - "expr": |
       sum without (device) (
-        rate(node_network_receive_bytes_total{job="node_exporter", device!="lo"}[1m])
+        rate(node_network_receive_bytes_total{job="node_exporter", device!="lo"}[5m])
       )
     "record": "instance:node_network_receive_bytes_excluding_lo:rate1m"
   - "expr": |
       sum without (device) (
-        rate(node_network_transmit_bytes_total{job="node_exporter", device!="lo"}[1m])
+        rate(node_network_transmit_bytes_total{job="node_exporter", device!="lo"}[5m])
       )
     "record": "instance:node_network_transmit_bytes_excluding_lo:rate1m"
   - "expr": |
       sum without (device) (
-        rate(node_network_receive_drop_total{job="node_exporter", device!="lo"}[1m])
+        rate(node_network_receive_drop_total{job="node_exporter", device!="lo"}[5m])
       )
     "record": "instance:node_network_receive_drop_excluding_lo:rate1m"
   - "expr": |
       sum without (device) (
-        rate(node_network_transmit_drop_total{job="node_exporter", device!="lo"}[1m])
+        rate(node_network_transmit_drop_total{job="node_exporter", device!="lo"}[5m])
       )
     "record": "instance:node_network_transmit_drop_excluding_lo:rate1m"


### PR DESCRIPTION
## Summary

- Recording rules used `rate(...[1m])` but `node_exporter` scrapes at 60s intervals
- With only one sample per minute, `rate()` requires at least 2 samples and was returning no data
- This blanked the network, CPU, and disk graphs in Grafana
- Changed all `rate()` windows to `[5m]` (>= 4× scrape interval, as recommended)
- Recording rule names are unchanged — no dashboard updates needed

## Test plan

- [ ] Merge to main and confirm webhook reloads Prometheus
- [ ] Verify network/CPU graphs in Grafana populate within ~60s of reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)