### PR TITLE
fix: add no_root_squash to rabbitseason NFS exports

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -30,11 +30,13 @@ nfs_server:
                                                 - 'rw'
                                                 - 'sync'
                                                 - 'no_subtree_check'
+                                                - 'no_root_squash'
                                           - hostname: 'localhost'
                                             options:
                                                 - 'rw'
                                                 - 'sync'
                                                 - 'no_subtree_check'
+                                                - 'no_root_squash'
                                   path: /srv
                                 - export:
                                   access:
@@ -43,11 +45,13 @@ nfs_server:
                                                 - 'rw'
                                                 - 'sync'
                                                 - 'no_subtree_check'
+                                                - 'no_root_squash'
                                           - hostname: 'localhost'
                                             options:
                                                 - 'rw'
                                                 - 'sync'
                                                 - 'no_subtree_check'
+                                                - 'no_root_squash'
                                   path: /mix
 
 login:


### PR DESCRIPTION
## Summary

- Adds `no_root_squash` to both `/srv` and `/mix` NFS exports on rabbitseason
- Fixes containers that run as root being unable to `chown` files on NFS mounts (root was silently remapped to nobody)

## Apply

```bash
ansible-playbook -i ansible/inventory.yml ansible/site-nfs.yml -l rabbitseason
```

Or manually on rabbitseason: `sudo exportfs -ra` after the playbook updates `/etc/exports`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)