### PR TITLE
feat: alert on Newt tunnel connection spikes

### DIFF
--- a/monitoring/newt_alerting_rules.yml
+++ b/monitoring/newt_alerting_rules.yml
@@ -1,0 +1,20 @@
+groups:
+- name: newt
+  rules:
+
+  # Fire when a lot of new proxy connections are accepted in a short window.
+  # newt_proxy_accept_total counts every connection accepted through the tunnel,
+  # so a spike here means something is hammering the exposed services.
+  # Threshold: >20 new connections in 5 minutes (sustained for 2m) is unusual
+  # for a personal homelab tunnel — tune this down if you add high-traffic services.
+  - alert: NewtConnectionSpike
+    expr: |
+      sum(increase(newt_proxy_accept_total[5m])) > 20
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Newt: high rate of new tunnel connections"
+      description: >
+        {{ $value | humanize }} new proxy connections accepted in the last 5 minutes.
+        Something may be hammering a tunnelled service.

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -9,6 +9,7 @@ rule_files:
   - "nomad_botherer_alerting_rules.yml"
   - "consul_alerting_rules.yml"
   - "grafana-sm-alerting-rules.yml"
+  - "newt_alerting_rules.yml"
 
 alerting:
   alertmanagers:
@@ -99,6 +100,7 @@ scrape_configs:
           - http://miniflux.service.home.consul:8080/rss
           - z2m.service.home.consul:8081
           - nomad-botherer.service.home.consul:9112
+          - newt.service.home.consul:2112
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target


### PR DESCRIPTION
## Summary

- Adds `monitoring/newt_alerting_rules.yml` with a `NewtConnectionSpike` alert
- Fires (warning) when `newt_proxy_accept_total` increases by more than 20 in a 5-minute window, sustained for 2 minutes
- Newt was already being scraped at `newt.service.home.consul:2112` — no scrape config changes needed
- Also adds newt's metrics endpoint to `blackbox-consul-http` probes so `ConsulServiceDown` fires if Newt goes away entirely

## Alert logic

```
sum(increase(newt_proxy_accept_total[5m])) > 20  for 2m
```

`newt_proxy_accept_total` is a counter of proxy connections accepted per protocol. A spike here means something is hammering a tunnelled service. Threshold is 20 connections/5min — tune down if you add high-traffic services behind the tunnel.

## Test plan

- [ ] After merge + webhook reload, check Prometheus rules page shows `NewtConnectionSpike` as inactive
- [ ] Verify `newt_proxy_accept_total` series exists in Prometheus (confirms scrape is working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)