### PR TITLE
feat: add mysql-connect.sh script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,7 @@ Utility scripts for operating the homelab cluster.
 | `reload_prometheus_blackbox.sh` | POST `/-/reload` to the Blackbox Exporter via its Consul address. |
 | `nomad-diff.sh` | Show a diff of what would change if a Nomad job file were submitted (dry-run helper). |
 | `pg-connect.sh` | Open a psql session to the local postgres instance via its Consul address. |
+| `mysql-connect.sh` | Open a mysql shell to the local mysql instance via its Consul address. |
 | `grafana-sm-export-tfvars.py` | Reconstruct `terraform/grafana-sm/terraform.tfvars` from the live Grafana Cloud Synthetic Monitoring API. Run this if you've lost your local tfvars. See `docs/grafana-synthetic-monitoring.md`. |
 
 ## Monitoring validation

--- a/scripts/mysql-connect.sh
+++ b/scripts/mysql-connect.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# mysql-connect.sh — retrieve the mysql root password from Nomad and open a mysql shell.
+#
+# Fetches the password from the Nomad variable at nomad/jobs/mysql and connects
+# to mysql.service.home.consul as root.
+#
+# Requires: nomad CLI, mysql, jq
+# Requires: NOMAD_TOKEN set in environment
+# Optional: NOMAD_ADDR (default: http://127.0.0.1:4646)
+set -euo pipefail
+
+if [[ -z "${NOMAD_TOKEN:-}" ]]; then
+    echo "ERROR: NOMAD_TOKEN is not set" >&2
+    exit 1
+fi
+
+MYSQL_PWD=$(nomad var get -out=json nomad/jobs/mysql | jq -r '.Items.root_password')
+export MYSQL_PWD
+
+exec mysql -h mysql.service.home.consul -u root "$@"


### PR DESCRIPTION
Mirrors `pg-connect.sh` for MySQL.

Reads `root_password` from `nomad/jobs/mysql` via the Nomad API and opens a `mysql` shell against `mysql.service.home.consul` as root. Passes any extra CLI arguments through to `mysql`.

Requires: `nomad` CLI, `mysql` client, `jq`, `NOMAD_TOKEN` in environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)