### PR TITLE
feat: add no_follow_redirects option to SM HTTP checks

### DIFF
--- a/terraform/grafana-sm/checks.tf
+++ b/terraform/grafana-sm/checks.tf
@@ -21,8 +21,9 @@ resource "grafana_synthetic_monitoring_check" "http" {
 
   settings {
     http {
-      ip_version         = "V4"
-      valid_status_codes = each.value.valid_status_codes
+      ip_version          = "V4"
+      valid_status_codes  = each.value.valid_status_codes
+      no_follow_redirects = each.value.no_follow_redirects
 
       fail_if_body_matches_regexp     = each.value.fail_if_body_matches_regexp
       fail_if_body_not_matches_regexp = each.value.fail_if_body_not_matches_regexp

--- a/terraform/grafana-sm/terraform.tfvars.example
+++ b/terraform/grafana-sm/terraform.tfvars.example
@@ -27,6 +27,15 @@ http_checks = {
     fail_if_body_not_matches_regexp = ["ok"]
   }
 
+  # Example: endpoint that redirects on login — check the redirect itself, not the destination.
+  # no_follow_redirects stops the probe from following the 302 so valid_status_codes = [302] works.
+  "my-redirect-check" = {
+    target              = "https://example.com/login"
+    probes              = ["London"]
+    valid_status_codes  = [302]
+    no_follow_redirects = true
+  }
+
   # Example: internal admin UI that must NOT be reachable from the internet.
   # Prefix the job name with "internal-" — the alert rule fires if any probe
   # can reach it (probe_success == 1 for 5 minutes).

--- a/terraform/grafana-sm/variables.tf
+++ b/terraform/grafana-sm/variables.tf
@@ -43,6 +43,10 @@ EOT
     # fail_if_body_matches_regexp, or if it doesn't match any in fail_if_body_not_matches_regexp.
     fail_if_body_matches_regexp     = optional(list(string), [])
     fail_if_body_not_matches_regexp = optional(list(string), [])
+
+    # Set to true to treat redirects as a probe result rather than following them.
+    # Useful when the expected response IS a redirect (e.g. valid_status_codes = [302]).
+    no_follow_redirects = optional(bool, false)
   }))
   default = {}
 }


### PR DESCRIPTION
## Summary

Adds a `no_follow_redirects` option to the `http_checks` variable in the Grafana SM Terraform module. When set to `true`, the probe treats a redirect as the final response rather than following it — necessary when `valid_status_codes` includes a 3xx code.

Needed for the `go.home.andvari.net` check which expects a `302` on `/login`.

## Changes

- `variables.tf` — adds `no_follow_redirects = optional(bool, false)` to the check object type
- `checks.tf` — passes the value through to `settings.http.no_follow_redirects`
- `terraform.tfvars.example` — adds a documented example

🤖 Generated with [Claude Code](https://claude.com/claude-code)