### PR TITLE
feat: add Nomad job CPU and memory monitoring

### DIFF
--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -146,6 +146,9 @@ scrape_configs:
     params:
       format: [prometheus]
     scrape_interval: 30s
+    # Nomad metrics carry their own 'job' label (the Nomad job name).
+    # honor_labels preserves it instead of overwriting with "nomad".
+    honor_labels: true
     static_configs:
       - targets:
           - bebop:4646


### PR DESCRIPTION
## Summary

- `ansible/roles/hashicorp/files/nomad.hcl` — adds `prometheus_metrics = true` to the telemetry stanza (requires Ansible playbook run + Nomad restart on all nodes)
- `monitoring/prometheus.yml` — adds a `nomad` scrape job targeting all 6 cluster nodes at port 4646, with `honor_labels: true` so the Nomad job name is preserved as the `job` label
- `monitoring/grafana/dashboards/nomad-resources.json` — new dashboard with 6 panels: CPU usage, memory RSS, usage vs reservation (actual vs dashed reserved), CPU throttle time, memory swap

## Notes

`honor_labels: true` is required because Nomad's `nomad_client_allocs_*` metrics already carry a `job` label (the Nomad job name). Without it, Prometheus overwrites that label with the scrape job name (`nomad`), collapsing all per-job series into one.

## Activation

After merge, run the Ansible playbook to push the config change to all nodes:

```bash
ansible-playbook ansible/playbook.yml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)