### PR TITLE
feat: fix node-overview dashboard and add nodes-combined view

### DIFF
--- a/monitoring/grafana/dashboards/node-overview.json
+++ b/monitoring/grafana/dashboards/node-overview.json
@@ -63,19 +63,19 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "node_load1{job=\"node_exporter\", instance=~\"$instance\"} / count without(cpu)(count without(mode)(node_cpu_seconds_total{job=\"node_exporter\", instance=~\"$instance\"}))",
+          "expr": "node_load1{job=\"node_exporter\", instance=~\"$instance\"} / instance:node_num_cpu:sum{job=\"node_exporter\", instance=~\"$instance\"}",
           "legendFormat": "load1 / cpu",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "node_load5{job=\"node_exporter\", instance=~\"$instance\"} / count without(cpu)(count without(mode)(node_cpu_seconds_total{job=\"node_exporter\", instance=~\"$instance\"}))",
+          "expr": "node_load5{job=\"node_exporter\", instance=~\"$instance\"} / instance:node_num_cpu:sum{job=\"node_exporter\", instance=~\"$instance\"}",
           "legendFormat": "load5 / cpu",
           "refId": "B"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "node_load15{job=\"node_exporter\", instance=~\"$instance\"} / count without(cpu)(count without(mode)(node_cpu_seconds_total{job=\"node_exporter\", instance=~\"$instance\"}))",
+          "expr": "node_load15{job=\"node_exporter\", instance=~\"$instance\"} / instance:node_num_cpu:sum{job=\"node_exporter\", instance=~\"$instance\"}",
           "legendFormat": "load15 / cpu",
           "refId": "C"
         }

--- a/monitoring/grafana/dashboards/node-overview.json
+++ b/monitoring/grafana/dashboards/node-overview.json
@@ -3,7 +3,7 @@
   "uid": "node-overview",
   "tags": ["nodes", "node-exporter"],
   "schemaVersion": 40,
-  "version": 1,
+  "version": 2,
   "refresh": "1m",
   "time": { "from": "now-3h", "to": "now" },
   "timezone": "browser",
@@ -16,7 +16,7 @@
         "label": "Host",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(node_uname_info{job=\"node_exporter\"}, instance)",
+        "query": "label_values(node_cpu_seconds_total{job=\"node_exporter\"}, instance)",
         "refresh": 2,
         "sort": 1,
         "includeAll": false,
@@ -35,7 +35,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "instance:node_cpu_utilisation:rate1m{job=\"node_exporter\", instance=~\"$instance\"}",
+          "expr": "1 - avg without(cpu, mode)(rate(node_cpu_seconds_total{job=\"node_exporter\", mode=\"idle\", instance=~\"$instance\"}[5m]))",
           "legendFormat": "cpu used",
           "refId": "A"
         }
@@ -63,19 +63,19 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "instance:node_load1_per_cpu:ratio{job=\"node_exporter\", instance=~\"$instance\"}",
+          "expr": "node_load1{job=\"node_exporter\", instance=~\"$instance\"} / count without(cpu)(count without(mode)(node_cpu_seconds_total{job=\"node_exporter\", instance=~\"$instance\"}))",
           "legendFormat": "load1 / cpu",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "node_load5{job=\"node_exporter\", instance=~\"$instance\"} / instance:node_num_cpu:sum{job=\"node_exporter\", instance=~\"$instance\"}",
+          "expr": "node_load5{job=\"node_exporter\", instance=~\"$instance\"} / count without(cpu)(count without(mode)(node_cpu_seconds_total{job=\"node_exporter\", instance=~\"$instance\"}))",
           "legendFormat": "load5 / cpu",
           "refId": "B"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "node_load15{job=\"node_exporter\", instance=~\"$instance\"} / instance:node_num_cpu:sum{job=\"node_exporter\", instance=~\"$instance\"}",
+          "expr": "node_load15{job=\"node_exporter\", instance=~\"$instance\"} / count without(cpu)(count without(mode)(node_cpu_seconds_total{job=\"node_exporter\", instance=~\"$instance\"}))",
           "legendFormat": "load15 / cpu",
           "refId": "C"
         }
@@ -102,7 +102,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "instance:node_memory_utilisation:ratio{job=\"node_exporter\", instance=~\"$instance\"}",
+          "expr": "1 - (node_memory_MemAvailable_bytes{job=\"node_exporter\", instance=~\"$instance\"} / node_memory_MemTotal_bytes{job=\"node_exporter\", instance=~\"$instance\"})",
           "legendFormat": "used",
           "refId": "A"
         }
@@ -169,7 +169,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "instance_device:node_disk_io_time_seconds:rate1m{job=\"node_exporter\", instance=~\"$instance\", device!~\"loop.*\"}",
+          "expr": "rate(node_disk_io_time_seconds_total{job=\"node_exporter\", instance=~\"$instance\", device!~\"loop.*\"}[5m])",
           "legendFormat": "{{device}}",
           "refId": "A"
         }
@@ -238,7 +238,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "instance:node_network_receive_bytes_excluding_lo:rate1m{job=\"node_exporter\", instance=~\"$instance\"}",
+          "expr": "sum without(device)(rate(node_network_receive_bytes_total{job=\"node_exporter\", instance=~\"$instance\", device!=\"lo\"}[5m]))",
           "legendFormat": "rx",
           "refId": "A"
         }
@@ -265,7 +265,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "instance:node_network_transmit_bytes_excluding_lo:rate1m{job=\"node_exporter\", instance=~\"$instance\"}",
+          "expr": "sum without(device)(rate(node_network_transmit_bytes_total{job=\"node_exporter\", instance=~\"$instance\", device!=\"lo\"}[5m]))",
           "legendFormat": "tx",
           "refId": "A"
         }

--- a/monitoring/grafana/dashboards/nodes-combined.json
+++ b/monitoring/grafana/dashboards/nodes-combined.json
@@ -47,7 +47,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "node_load1{job=\"node_exporter\"} / count without(cpu)(count without(mode)(node_cpu_seconds_total{job=\"node_exporter\"}))",
+          "expr": "node_load1{job=\"node_exporter\"} / instance:node_num_cpu:sum{job=\"node_exporter\"}",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }

--- a/monitoring/grafana/dashboards/nodes-combined.json
+++ b/monitoring/grafana/dashboards/nodes-combined.json
@@ -1,0 +1,179 @@
+{
+  "title": "Nodes Combined",
+  "uid": "nodes-combined",
+  "tags": ["nodes", "node-exporter"],
+  "schemaVersion": 40,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-3h", "to": "now" },
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "id": 1,
+      "title": "CPU Utilization",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "1 - avg without(cpu, mode)(rate(node_cpu_seconds_total{job=\"node_exporter\", mode=\"idle\"}[5m]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Load per CPU",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "node_load1{job=\"node_exporter\"} / count without(cpu)(count without(mode)(node_cpu_seconds_total{job=\"node_exporter\"}))",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Memory Utilization",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "1 - (node_memory_MemAvailable_bytes{job=\"node_exporter\"} / node_memory_MemTotal_bytes{job=\"node_exporter\"})",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Disk IO Busy",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "max by(instance)(rate(node_disk_io_time_seconds_total{job=\"node_exporter\", device!~\"loop.*\"}[5m]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Network Receive",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum without(device)(rate(node_network_receive_bytes_total{job=\"node_exporter\", device!=\"lo\"}[5m]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "binBps",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Network Transmit",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum without(device)(rate(node_network_transmit_bytes_total{job=\"node_exporter\", device!=\"lo\"}[5m]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "binBps",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- **node-overview**: panels using Prometheus recording rules (`instance:node_cpu_utilisation:rate1m` etc.) were blank because they depend on recording rule evaluation. Replaced with direct PromQL expressions. Also switched the template variable from `node_uname_info` to `node_cpu_seconds_total` for reliability.
- **nodes-combined**: new dashboard showing CPU, load, memory, disk IO, and network for all hosts on a single graph each (one line per instance, no host filter variable).

## Test plan

- [ ] Push to main triggers webhook → Grafana reloads dashboards from gitrepo volume
- [ ] Open Node Overview in Grafana, select a host — all 8 panels should show data
- [ ] Open Nodes Combined — each graph shows one line per host
🤖 Generated with [Claude Code](https://claude.com/claude-code)