### PR TITLE
fix: node dashboard load panel blank due to recording rule

### DIFF
--- a/monitoring/grafana/dashboards/node-overview.json
+++ b/monitoring/grafana/dashboards/node-overview.json
@@ -63,19 +63,19 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "node_load1{job=\"node_exporter\", instance=~\"$instance\"} / instance:node_num_cpu:sum{job=\"node_exporter\", instance=~\"$instance\"}",
+          "expr": "node_load1{job=\"node_exporter\", instance=~\"$instance\"} / count without(cpu)(count without(mode)(node_cpu_seconds_total{job=\"node_exporter\", instance=~\"$instance\"}))",
           "legendFormat": "load1 / cpu",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "node_load5{job=\"node_exporter\", instance=~\"$instance\"} / instance:node_num_cpu:sum{job=\"node_exporter\", instance=~\"$instance\"}",
+          "expr": "node_load5{job=\"node_exporter\", instance=~\"$instance\"} / count without(cpu)(count without(mode)(node_cpu_seconds_total{job=\"node_exporter\", instance=~\"$instance\"}))",
           "legendFormat": "load5 / cpu",
           "refId": "B"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "node_load15{job=\"node_exporter\", instance=~\"$instance\"} / instance:node_num_cpu:sum{job=\"node_exporter\", instance=~\"$instance\"}",
+          "expr": "node_load15{job=\"node_exporter\", instance=~\"$instance\"} / count without(cpu)(count without(mode)(node_cpu_seconds_total{job=\"node_exporter\", instance=~\"$instance\"}))",
           "legendFormat": "load15 / cpu",
           "refId": "C"
         }

--- a/monitoring/grafana/dashboards/nodes-combined.json
+++ b/monitoring/grafana/dashboards/nodes-combined.json
@@ -47,7 +47,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "node_load1{job=\"node_exporter\"} / instance:node_num_cpu:sum{job=\"node_exporter\"}",
+          "expr": "node_load1{job=\"node_exporter\"} / count without(cpu)(count without(mode)(node_cpu_seconds_total{job=\"node_exporter\"}))",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }


### PR DESCRIPTION
## Summary

- The Load per CPU panel in both `node-overview` and `nodes-combined` was blank because the divisor used `instance:node_num_cpu:sum` (a recording rule), which isn't being evaluated.
- Replaced with the equivalent inline PromQL: `count without(cpu)(count without(mode)(node_cpu_seconds_total{...}))`.

Follow-up to #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)