### PR TITLE
fix: dial back job resource allocations based on p95/p99 usage

### DIFF
--- a/nomad/apps/birdnet/birdnet.hcl
+++ b/nomad/apps/birdnet/birdnet.hcl
@@ -51,8 +51,8 @@ EOF
         destination = "/data"
       }
       resources {
-        cpu = 2000
-        memory = 2048
+        cpu    = 1200
+        memory = 1024
       }
     }
     network {

--- a/nomad/apps/kutt/kutt.hcl
+++ b/nomad/apps/kutt/kutt.hcl
@@ -64,7 +64,7 @@ EOF
       }
 
       resources {
-        cpu    = 256
+        cpu    = 100
         memory = 256
       }
     }

--- a/nomad/infra/databasus/databasus.hcl
+++ b/nomad/infra/databasus/databasus.hcl
@@ -42,8 +42,8 @@ job "databasus" {
       }
 
       resources {
-        cpu    = 500
-        memory = 512
+        cpu    = 100
+        memory = 256
       }
     }
   }

--- a/nomad/infra/homelab-webhook/homelab-webhook.hcl
+++ b/nomad/infra/homelab-webhook/homelab-webhook.hcl
@@ -58,7 +58,7 @@ EOF
 
       resources {
         cpu    = 100
-        memory = 128
+        memory = 64
       }
     }
 
@@ -118,7 +118,7 @@ EOF
 
       resources {
         cpu    = 100
-        memory = 128
+        memory = 64
       }
     }
 

--- a/nomad/infra/mysql/mysql.hcl
+++ b/nomad/infra/mysql/mysql.hcl
@@ -52,8 +52,8 @@ EOH
       }
 
       resources {
-        cpu    = 500
-        memory = 512
+        cpu    = 100
+        memory = 1024
       }
     }
 

--- a/nomad/infra/postfix-andvari-smarthost/postfix-andvari-smarthost.hcl
+++ b/nomad/infra/postfix-andvari-smarthost/postfix-andvari-smarthost.hcl
@@ -17,8 +17,8 @@ job "postfix-andvari-smarthost" {
         ports = ["smtp"]
       }
       resources {
-        cpu = 1000
-        memory = 512
+        cpu    = 100
+        memory = 64
      }
      env {
        POSTFIX_mydestination = "home.andvari.net"

--- a/nomad/infra/postgres/postgres.hcl
+++ b/nomad/infra/postgres/postgres.hcl
@@ -29,8 +29,8 @@ job "postgres" {
         ports = ["postgres"]
       }
       resources {
-        cpu = 2000
-        memory = 1024
+        cpu    = 200
+        memory = 512
      }
 
      template {

--- a/nomad/infra/traefik/traefik.hcl
+++ b/nomad/infra/traefik/traefik.hcl
@@ -227,7 +227,7 @@ EOH
 
       resources {
         cpu    = 200
-        memory = 256
+        memory = 64
       }
     }
   }

--- a/nomad/infra/z2m/z2m.hcl
+++ b/nomad/infra/z2m/z2m.hcl
@@ -29,8 +29,8 @@ job "z2m" {
         privileged = true
       }
       resources {
-        cpu = 2000
-        memory = 1024
+        cpu    = 100
+        memory = 256
      }
      env {
        TZ = "Europe/Dublin"

--- a/nomad/monitoring/grafana.hcl
+++ b/nomad/monitoring/grafana.hcl
@@ -79,8 +79,8 @@ EOH
       }
 
       resources {
-        cpu    = 500
-        memory = 512
+        cpu    = 200
+        memory = 128
       }
     }
   }

--- a/nomad/monitoring/prom-alertmanager.hcl
+++ b/nomad/monitoring/prom-alertmanager.hcl
@@ -45,8 +45,8 @@ job "prom-alertmanager" {
         destination = "/config"
       }
       resources {
-        cpu = 1000
-        memory = 1000
+        cpu    = 100
+        memory = 64
      }
     }
 

--- a/nomad/monitoring/prom-blackbox-exporter.hcl
+++ b/nomad/monitoring/prom-blackbox-exporter.hcl
@@ -30,8 +30,8 @@ job "prom-blackbox-exporter" {
         destination = "/config"
       }
       resources {
-        cpu = 1000
-        memory = 1000
+        cpu    = 200
+        memory = 64
      }
     }
 

--- a/nomad/monitoring/prom-consul-exporter.hcl
+++ b/nomad/monitoring/prom-consul-exporter.hcl
@@ -18,8 +18,8 @@ job "prom-consul-exporter" {
         ports = ["prom-consul-exporter"]
       }
       resources {
-        cpu = 500
-        memory = 500
+        cpu    = 100
+        memory = 64
      }
     }
 

--- a/nomad/monitoring/prometheus.hcl
+++ b/nomad/monitoring/prometheus.hcl
@@ -79,8 +79,8 @@ EOH
         destination = "/config"
       }
       resources {
-        cpu = 2000
-        memory = 2000
+        cpu    = 200
+        memory = 512
      }
     }
 

--- a/nomad/storage/rabbitseason-mix-nfs-controller.hcl
+++ b/nomad/storage/rabbitseason-mix-nfs-controller.hcl
@@ -28,8 +28,8 @@ job "rabbitseason-mix-nfs-controller" {
       }
 
       resources {
-        cpu    = 500
-        memory = 256
+        cpu    = 100
+        memory = 128
       }
 
     }

--- a/nomad/storage/rabbitseason-mix-nfs-node.hcl
+++ b/nomad/storage/rabbitseason-mix-nfs-node.hcl
@@ -29,8 +29,8 @@ job "rabbitseason-mix-nfs-node" {
       }
 
       resources {
-        cpu    = 500
-        memory = 256
+        cpu    = 100
+        memory = 128
       }
 
     }

--- a/nomad/storage/rabbitseason-srv-nfs-controller.hcl
+++ b/nomad/storage/rabbitseason-srv-nfs-controller.hcl
@@ -28,8 +28,8 @@ job "rabbitseason-srv-nfs-controller" {
       }
 
       resources {
-        cpu    = 500
-        memory = 256
+        cpu    = 100
+        memory = 128
       }
 
     }

--- a/nomad/storage/rabbitseason-srv-nfs-node.hcl
+++ b/nomad/storage/rabbitseason-srv-nfs-node.hcl
@@ -29,8 +29,8 @@ job "rabbitseason-srv-nfs-node" {
       }
 
       resources {
-        cpu    = 500
-        memory = 256
+        cpu    = 100
+        memory = 128
       }
 
     }

--- a/nomad/storage/rocketduck-controller.hcl
+++ b/nomad/storage/rocketduck-controller.hcl
@@ -28,8 +28,8 @@ job "storage-controller" {
       }
 
       resources {
-        cpu    = 500
-        memory = 256
+        cpu    = 100
+        memory = 128
       }
 
     }

--- a/nomad/storage/rocketduck-node.hcl
+++ b/nomad/storage/rocketduck-node.hcl
@@ -29,8 +29,8 @@ job "storage-node" {
       }
 
       resources {
-        cpu    = 500
-        memory = 256
+        cpu    = 100
+        memory = 128
       }
 
     }


### PR DESCRIPTION
## Summary

Queried 7-day p95/p99 CPU and memory usage from Prometheus (`nomad_client_allocs_cpu_total_ticks`, `nomad_client_allocs_memory_rss`) and adjusted resource blocks to ~2x the p99 observed value. Most jobs were wildly over-allocated.

**One exception:** `mysql` memory was *increased* — its p99 RSS (502 MB) was within 2% of its configured limit (512 MB), putting it at OOM risk.

| Job | CPU MHz | Memory MB | Notes |
|-----|---------|-----------|-------|
| **prometheus** | 2000 → **200** | 2000 → **512** | p99: 25 MHz / 126 MB |
| **prom-alertmanager** | 1000 → **100** | 1000 → **64** | p99: 6 MHz / 13 MB |
| **prom-blackbox-exporter** | 1000 → **200** | 1000 → **64** | p99: 57 MHz / 21 MB |
| **prom-consul-exporter** | 500 → **100** | 500 → **64** | p99: ~0 MHz / 10 MB |
| **grafana** | 500 → **200** | 512 → **128** | p99: 65 MHz / 58 MB |
| **postgres** | 2000 → **200** | 1024 → **512** | p99: 74 MHz (RSS looks low — kept 512 for safety) |
| **mysql** | 500 → **100** | 512 → **1024** ↑ | p99 RSS=502 MB — was dangerously close to OOM |
| **databasus** | 500 → **100** | 512 → **256** | p99: 15 MHz / 71 MB |
| **postfix-andvari-smarthost** | 1000 → **100** | 512 → **64** | p99: ~0 MHz / 27 MB |
| **z2m** | 2000 → **100** | 1024 → **256** | p99: 29 MHz / 92 MB |
| **birdnet** | 2000 → **1200** | 2048 → **1024** | p99: 541 MHz / 471 MB |
| **traefik** | 200 (kept) | 256 → **64** | p99: 101 MHz / 28 MB (CPU already right) |
| **kutt** | 256 → **100** | 256 (kept) | p99 mem=197 MB — only 1.3x headroom, kept |
| **homelab-webhook** | 100 (kept) | 128 → **64** | p99: 3 MHz / 23 MB |
| **nomad-botherer** | 100 (kept) | 128 → **64** | same |
| **storage-controller** (rocketduck) | 500 → **100** | 256 → **128** | p99: 4 MHz / 24 MB |
| **storage-node** (rocketduck) | 500 → **100** | 256 → **128** | p99: 9 MHz / 23 MB |
| **rabbitseason-\*-nfs-{controller,node}** (×4) | 500 → **100** | 256 → **128** | p99: 8–14 MHz / 23–24 MB |

## Test plan

- [ ] Deploy each changed job and verify it starts cleanly
- [ ] Monitor for OOM kills or CPU throttling over the next 24–48h
- [ ] Check `nomad job status <job>` for any allocation failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)