### PR TITLE
fix: nomad-resources dashboard memory reservation shown in PB

### DIFF
--- a/monitoring/grafana/dashboards/nomad-resources.json
+++ b/monitoring/grafana/dashboards/nomad-resources.json
@@ -128,7 +128,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum by (job) (nomad_client_allocs_memory_allocated{job!=\"\"})",
+          "expr": "sum by (job) (nomad_client_allocs_memory_allocated{job!=\"\"}) / 1024 / 1024",
           "legendFormat": "{{job}} reserved",
           "refId": "B"
         }


### PR DESCRIPTION
## Summary

- `nomad_client_allocs_memory_allocated` reports bytes, but the \"Memory Usage vs Reservation\" panel was missing the `/1024/1024` conversion applied to every other memory expression in the dashboard
- Grafana's `decmbytes` unit expects values in MB, so raw byte values (e.g. 10,485,760,000 for a 10 GiB reservation) were being displayed as ~10 PB

## Test plan

- [ ] Merge and verify the reservation series in the \"Memory Usage vs Reservation by Job\" panel shows sensible MiB/GiB values

🤖 Generated with [Claude Code](https://claude.com/claude-code)