### PR TITLE
fix: prometheus rule files never loaded — all recording rules broken

### DIFF
--- a/.github/workflows/monitoring-validate.yml
+++ b/.github/workflows/monitoring-validate.yml
@@ -20,22 +20,22 @@ jobs:
         run: |
           docker run --rm \
             --entrypoint promtool \
-            -v "$GITHUB_WORKSPACE/monitoring:/monitoring:ro" \
+            -v "$GITHUB_WORKSPACE/config/monitoring:/config/monitoring:ro" \
             prom/prometheus:v3.10.0 \
-            check config /monitoring/prometheus.yml
+            check config /config/monitoring/prometheus.yml
 
       - name: Validate alertmanager config
         run: |
           docker run --rm \
             --entrypoint /bin/amtool \
-            -v "$GITHUB_WORKSPACE/monitoring:/monitoring:ro" \
+            -v "$GITHUB_WORKSPACE/config/monitoring:/config/monitoring:ro" \
             prom/alertmanager \
-            check-config /monitoring/prom-alertmanager.yml
+            check-config /config/monitoring/prom-alertmanager.yml
 
       - name: Validate blackbox-exporter config
         run: |
           docker run --rm \
-            -v "$GITHUB_WORKSPACE/monitoring:/monitoring:ro" \
+            -v "$GITHUB_WORKSPACE/config/monitoring:/config/monitoring:ro" \
             prom/blackbox-exporter \
-            --config.file=/monitoring/prom-blackbox-exporter.yml \
+            --config.file=/config/monitoring/prom-blackbox-exporter.yml \
             --config.check

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -3,13 +3,13 @@ global:
   evaluation_interval: 15s
 
 rule_files:
-  - "blackbox_alerting_rules.yml"
-  - "node_exporter_recording_rules.yml"
-  - "node_exporter_alerting_rules.yml"
-  - "nomad_botherer_alerting_rules.yml"
-  - "consul_alerting_rules.yml"
-  - "grafana-sm-alerting-rules.yml"
-  - "newt_alerting_rules.yml"
+  - "/config/monitoring/blackbox_alerting_rules.yml"
+  - "/config/monitoring/node_exporter_recording_rules.yml"
+  - "/config/monitoring/node_exporter_alerting_rules.yml"
+  - "/config/monitoring/nomad_botherer_alerting_rules.yml"
+  - "/config/monitoring/consul_alerting_rules.yml"
+  - "/config/monitoring/grafana-sm-alerting-rules.yml"
+  - "/config/monitoring/newt_alerting_rules.yml"
 
 alerting:
   alertmanagers:

--- a/scripts/check-monitoring-configs.sh
+++ b/scripts/check-monitoring-configs.sh
@@ -10,26 +10,26 @@ echo ""
 echo "--- prometheus config ---"
 docker run --rm \
   --entrypoint promtool \
-  -v "${MONITORING_DIR}:/monitoring:ro" \
+  -v "${MONITORING_DIR}:/config/monitoring:ro" \
   prom/prometheus:v3.10.0 \
-  check config /monitoring/prometheus.yml
+  check config /config/monitoring/prometheus.yml
 echo "PASS: prometheus config"
 
 echo ""
 echo "--- alertmanager config ---"
 docker run --rm \
   --entrypoint /bin/amtool \
-  -v "${MONITORING_DIR}:/monitoring:ro" \
+  -v "${MONITORING_DIR}:/config/monitoring:ro" \
   prom/alertmanager \
-  check-config /monitoring/prom-alertmanager.yml
+  check-config /config/monitoring/prom-alertmanager.yml
 echo "PASS: alertmanager config"
 
 echo ""
 echo "--- blackbox-exporter config ---"
 docker run --rm \
-  -v "${MONITORING_DIR}:/monitoring:ro" \
+  -v "${MONITORING_DIR}:/config/monitoring:ro" \
   prom/blackbox-exporter \
-  --config.file=/monitoring/prom-blackbox-exporter.yml \
+  --config.file=/config/monitoring/prom-blackbox-exporter.yml \
   --config.check
 echo "PASS: blackbox-exporter config"
 


### PR DESCRIPTION
## Summary

- The startup script in `prometheus.hcl` builds `/local/prometheus.yml` by concatenating the gitrepo config with remote_read credentials, so relative `rule_files` paths resolved to `/local/` — which is empty
- Prometheus treats missing rule files as empty rather than a config error (`reloadConfigSuccess: true`), so it silently loaded zero rule groups
- All 11 recording rules were never evaluated, breaking every Grafana panel that depends on them (network, CPU, memory overviews)
- Fix: use absolute `/config/monitoring/` paths in `rule_files`, matching where the gitrepo CSI volume is mounted
- Also align `check-monitoring-configs.sh` and the CI workflow to mount at `/config/monitoring` so the same paths validate correctly locally and in CI

## Test plan

- [ ] Merge and push to main so the webhook triggers `/-/reload` on Prometheus
- [ ] Verify `http://prometheus.service.home.consul:9090/api/v1/rules` returns 7 rule groups (was returning empty)
- [ ] Verify network/CPU/memory panels in Grafana populate within a few minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)