### PR TITLE
fix: correct host-side mount path in CI monitoring workflow

### DIFF
--- a/.github/workflows/monitoring-validate.yml
+++ b/.github/workflows/monitoring-validate.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           docker run --rm \
             --entrypoint promtool \
-            -v "$GITHUB_WORKSPACE/config/monitoring:/config/monitoring:ro" \
+            -v "$GITHUB_WORKSPACE/monitoring:/config/monitoring:ro" \
             prom/prometheus:v3.10.0 \
             check config /config/monitoring/prometheus.yml
 
@@ -28,14 +28,14 @@ jobs:
         run: |
           docker run --rm \
             --entrypoint /bin/amtool \
-            -v "$GITHUB_WORKSPACE/config/monitoring:/config/monitoring:ro" \
+            -v "$GITHUB_WORKSPACE/monitoring:/config/monitoring:ro" \
             prom/alertmanager \
             check-config /config/monitoring/prom-alertmanager.yml
 
       - name: Validate blackbox-exporter config
         run: |
           docker run --rm \
-            -v "$GITHUB_WORKSPACE/config/monitoring:/config/monitoring:ro" \
+            -v "$GITHUB_WORKSPACE/monitoring:/config/monitoring:ro" \
             prom/blackbox-exporter \
             --config.file=/config/monitoring/prom-blackbox-exporter.yml \
             --config.check


### PR DESCRIPTION
## Summary

- Fixes a bad `replace_all` from #81 that changed `$GITHUB_WORKSPACE/monitoring` to `$GITHUB_WORKSPACE/config/monitoring` on the host side of the Docker volume mount
- That path doesn't exist in the repo checkout, so promtool couldn't find the config file
- Only the container-side mount target needed to change to `/config/monitoring`; the host side should remain `$GITHUB_WORKSPACE/monitoring`

## Test plan

- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)