### PR TITLE
feat: add Nomad job memory and CPU resource alerts

### DIFF
--- a/monitoring/nomad_resource_alerting_rules.yml
+++ b/monitoring/nomad_resource_alerting_rules.yml
@@ -1,0 +1,32 @@
+"groups":
+- "name": "nomad-resources"
+  "rules":
+
+  # Fires when a task's RSS exceeds its memory reservation for 5 minutes.
+  # This means the task is over its soft limit; with oversubscription enabled
+  # it won't be OOM-killed until it hits memory_max, but it's a sign the
+  # reservation needs raising.
+  - "alert": "NomadJobMemoryOverReservation"
+    "annotations":
+      "summary": "{{ $labels.job }}/{{ $labels.task }} is over its memory reservation"
+      "description": "{{ $labels.job }}/{{ $labels.task }} on {{ $labels.host }} has been using {{ $value | humanize }}B above its reservation for 5 minutes. Consider raising the memory reservation."
+    "expr": |
+      (
+        nomad_client_allocs_memory_usage - nomad_client_allocs_memory_allocated
+      ) > 0
+    "for": "5m"
+    "labels":
+      "severity": "warning"
+
+  # Fires when a task is actively CPU-throttled for 5 minutes.
+  # Throttling means the task is hitting its cgroup CPU quota ceiling —
+  # the reservation is too low and the task is being starved.
+  - "alert": "NomadJobCPUThrottled"
+    "annotations":
+      "summary": "{{ $labels.job }}/{{ $labels.task }} is CPU throttled"
+      "description": "{{ $labels.job }}/{{ $labels.task }} on {{ $labels.host }} has been CPU throttled for 5 minutes. Consider raising the CPU reservation."
+    "expr": |
+      rate(nomad_client_allocs_cpu_throttled_time{job!=""}[5m]) > 0
+    "for": "5m"
+    "labels":
+      "severity": "warning"

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -10,6 +10,7 @@ rule_files:
   - "/config/monitoring/consul_alerting_rules.yml"
   - "/config/monitoring/grafana-sm-alerting-rules.yml"
   - "/config/monitoring/newt_alerting_rules.yml"
+  - "/config/monitoring/nomad_resource_alerting_rules.yml"
 
 alerting:
   alertmanagers:


### PR DESCRIPTION
## Summary

- `NomadJobMemoryOverReservation`: fires when a task's RSS exceeds its memory reservation for 5 minutes — indicates the reservation needs raising. With oversubscription enabled the task won't OOM until `memory_max`, but it's an early signal to act.
- `NomadJobCPUThrottled`: fires when a task has been CPU-throttled for 5 minutes, meaning it's hitting its cgroup CPU quota ceiling and being actively starved.

## Test plan

- [ ] CI passes
- [ ] After merge + reload, verify alerts appear in Prometheus at `http://prometheus.service.home.consul:9090/alerts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)