### PR TITLE
fix: prometheus config reloads automatically on gitrepo changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,9 @@ Key volumes:
 
 Config files live in `monitoring/` and are mounted into prometheus/alertmanager/blackbox-exporter via the `gitrepo` CSI volume.
 
-On push to main, the `homelab-webhook` Nomad job (at `nomad/infra/homelab-webhook/`) pulls the repo and POSTs `/-/reload` to prometheus (9090), alertmanager (9093), and blackbox-exporter (9115).
+On push to main, the `homelab-webhook` Nomad job (at `nomad/infra/homelab-webhook/`) pulls the repo and POSTs `/-/reload` to alertmanager (9093) and blackbox-exporter (9115).
+
+Prometheus reloads automatically: its Nomad template uses `{{ file "/config/monitoring/prometheus.yml" }}`, so Nomad watches the gitrepo file for changes and sends SIGHUP to Prometheus when it changes. No explicit `/-/reload` call is needed for Prometheus config changes. Credential rotations (Nomad var changes) also trigger a graceful reload via the same mechanism.
 
 Prometheus requires `--web.enable-lifecycle` to enable `/-/reload`. Alertmanager and blackbox-exporter enable it by default.
 

--- a/nomad/monitoring/prometheus.hcl
+++ b/nomad/monitoring/prometheus.hcl
@@ -25,12 +25,17 @@ job "prometheus" {
       }
       driver = "docker"
 
-      # Grafana Cloud remote_read credentials from nomad/jobs/prometheus.
-      # Written to /local/remote_read.yml and concatenated with the gitrepo
-      # prometheus.yml at startup by /local/start.sh.
-      # change_mode=restart ensures Prometheus picks up credential rotations.
+      # Render the complete Prometheus config by reading prometheus.yml from
+      # the gitrepo and appending Grafana Cloud remote_read credentials.
+      #
+      # Using {{ file }} causes Nomad to watch /config/monitoring/prometheus.yml
+      # for changes. When the webhook pulls new code, Nomad detects the change,
+      # re-renders this template, and sends SIGHUP to Prometheus — triggering a
+      # graceful reload automatically, with no container restart needed.
+      # Credential rotations (Nomad var changes) also trigger a graceful reload.
       template {
         data = <<EOH
+{{ file "/config/monitoring/prometheus.yml" }}
 remote_read:
   - url: "https://{{ with nomadVar "nomad/jobs/prometheus" }}{{ .grafana_metrics_host }}{{ end }}/api/prom/api/v1/read"
     basic_auth:
@@ -38,32 +43,19 @@ remote_read:
       password: "{{ with nomadVar "nomad/jobs/prometheus" }}{{ .grafana_metrics_read_token }}{{ end }}"
     read_recent: true
 EOH
-        destination = "local/remote_read.yml"
-        change_mode = "restart"
-      }
-
-      # Startup script: concatenate the gitrepo prometheus.yml with the
-      # remote_read section, then exec Prometheus against the combined file.
-      # Alert rule files are loaded from /config/monitoring/ (gitrepo) so
-      # /-/reload still picks up rule changes pushed via the webhook.
-      template {
-        data = <<EOH
-#!/bin/sh
-set -e
-cat /config/monitoring/prometheus.yml /local/remote_read.yml > /local/prometheus.yml
-exec /bin/prometheus \
-  --config.file=/local/prometheus.yml \
-  --storage.tsdb.path=/data/prometheus/prom-tsdb/ \
-  --web.external-url=http://prometheus.service.home.consul:9090/ \
-  --web.enable-lifecycle
-EOH
-        destination = "local/start.sh"
-        change_mode = "noop"
+        destination = "local/prometheus.yml"
+        change_mode = "signal"
+        change_signal = "SIGHUP"
       }
 
       config {
-        image      = "prom/prometheus:v3.10.0"
-        entrypoint = ["/bin/sh", "/local/start.sh"]
+        image  = "prom/prometheus:v3.10.0"
+        args   = [
+          "--config.file=/local/prometheus.yml",
+          "--storage.tsdb.path=/data/prometheus/prom-tsdb/",
+          "--web.external-url=http://prometheus.service.home.consul:9090/",
+          "--web.enable-lifecycle",
+        ]
         labels {
           group = "prometheus"
         }


### PR DESCRIPTION
## Summary

- Previously, `start.sh` ran once at startup to concatenate `prometheus.yml` + `remote_read.yml` into `/local/prometheus.yml`. A `/-/reload` just re-read that stale file, so any change to `prometheus.yml` in the gitrepo required a full container restart.
- New approach: a single Nomad template renders the complete config using `{{ file "/config/monitoring/prometheus.yml" }}`. Consul-template watches the gitrepo file for changes — when the webhook's `git pull` updates it, Nomad re-renders the template and sends SIGHUP to Prometheus for a graceful reload automatically.
- Credential rotations (Nomad var changes) also trigger a graceful reload via the same mechanism, instead of a restart.
- Removes the startup script; Prometheus flags are passed via `args` in the `config` block.

## Test plan

- [ ] Deploy with `nomad job run nomad/monitoring/prometheus.hcl` (one-time restart to pick up the new approach)
- [ ] Verify Prometheus starts and rule groups load: `curl http://prometheus.service.home.consul:9090/api/v1/rules`
- [ ] Push a change to `monitoring/prometheus.yml` on main and verify Prometheus reloads without a restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)