### PR TITLE
fix: use glob for rule_files, graceful reload on credential rotation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,9 @@ Key volumes:
 
 Config files live in `monitoring/` and are mounted into prometheus/alertmanager/blackbox-exporter via the `gitrepo` CSI volume.
 
-On push to main, the `homelab-webhook` Nomad job (at `nomad/infra/homelab-webhook/`) pulls the repo and POSTs `/-/reload` to alertmanager (9093) and blackbox-exporter (9115).
+On push to main, the `homelab-webhook` Nomad job (at `nomad/infra/homelab-webhook/`) pulls the repo and POSTs `/-/reload` to prometheus (9090), alertmanager (9093), and blackbox-exporter (9115).
 
-Prometheus reloads automatically: its Nomad template uses `{{ file "/config/monitoring/prometheus.yml" }}`, so Nomad watches the gitrepo file for changes and sends SIGHUP to Prometheus when it changes. No explicit `/-/reload` call is needed for Prometheus config changes. Credential rotations (Nomad var changes) also trigger a graceful reload via the same mechanism.
+Prometheus's startup script concatenates the gitrepo `prometheus.yml` with a Nomad-rendered `remote_read.yml` into `/local/prometheus.yml`. The `/-/reload` endpoint re-reads this file; rule files are loaded via a glob (`/config/monitoring/*_rules.yml`) so new rule files are picked up by `/-/reload` without modifying `prometheus.yml`. Credential rotations trigger a graceful SIGHUP reload via `change_mode=signal` on the remote_read template. Changes to `prometheus.yml` itself (e.g. new scrape jobs) require a `nomad job run` redeploy.
 
 Prometheus requires `--web.enable-lifecycle` to enable `/-/reload`. Alertmanager and blackbox-exporter enable it by default.
 

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -3,14 +3,7 @@ global:
   evaluation_interval: 15s
 
 rule_files:
-  - "/config/monitoring/blackbox_alerting_rules.yml"
-  - "/config/monitoring/node_exporter_recording_rules.yml"
-  - "/config/monitoring/node_exporter_alerting_rules.yml"
-  - "/config/monitoring/nomad_botherer_alerting_rules.yml"
-  - "/config/monitoring/consul_alerting_rules.yml"
-  - "/config/monitoring/grafana-sm-alerting-rules.yml"
-  - "/config/monitoring/newt_alerting_rules.yml"
-  - "/config/monitoring/nomad_resource_alerting_rules.yml"
+  - "/config/monitoring/*_rules.yml"
 
 alerting:
   alertmanagers:

--- a/nomad/monitoring/prometheus.hcl
+++ b/nomad/monitoring/prometheus.hcl
@@ -25,17 +25,12 @@ job "prometheus" {
       }
       driver = "docker"
 
-      # Render the complete Prometheus config by reading prometheus.yml from
-      # the gitrepo and appending Grafana Cloud remote_read credentials.
-      #
-      # Using {{ file }} causes Nomad to watch /config/monitoring/prometheus.yml
-      # for changes. When the webhook pulls new code, Nomad detects the change,
-      # re-renders this template, and sends SIGHUP to Prometheus — triggering a
-      # graceful reload automatically, with no container restart needed.
-      # Credential rotations (Nomad var changes) also trigger a graceful reload.
+      # Grafana Cloud remote_read credentials from nomad/jobs/prometheus.
+      # Written to /local/remote_read.yml and concatenated with the gitrepo
+      # prometheus.yml at startup by /local/start.sh.
+      # change_mode=signal sends SIGHUP for a graceful reload on credential rotation.
       template {
         data = <<EOH
-{{ file "/config/monitoring/prometheus.yml" }}
 remote_read:
   - url: "https://{{ with nomadVar "nomad/jobs/prometheus" }}{{ .grafana_metrics_host }}{{ end }}/api/prom/api/v1/read"
     basic_auth:
@@ -43,19 +38,33 @@ remote_read:
       password: "{{ with nomadVar "nomad/jobs/prometheus" }}{{ .grafana_metrics_read_token }}{{ end }}"
     read_recent: true
 EOH
-        destination = "local/prometheus.yml"
+        destination = "local/remote_read.yml"
         change_mode = "signal"
         change_signal = "SIGHUP"
       }
 
+      # Startup script: concatenate the gitrepo prometheus.yml with the
+      # remote_read section, then exec Prometheus against the combined file.
+      # Rule files use a glob (/config/monitoring/*_rules.yml) so new rule
+      # files are picked up by /-/reload without touching prometheus.yml.
+      template {
+        data = <<EOH
+#!/bin/sh
+set -e
+cat /config/monitoring/prometheus.yml /local/remote_read.yml > /local/prometheus.yml
+exec /bin/prometheus \
+  --config.file=/local/prometheus.yml \
+  --storage.tsdb.path=/data/prometheus/prom-tsdb/ \
+  --web.external-url=http://prometheus.service.home.consul:9090/ \
+  --web.enable-lifecycle
+EOH
+        destination = "local/start.sh"
+        change_mode = "noop"
+      }
+
       config {
-        image  = "prom/prometheus:v3.10.0"
-        args   = [
-          "--config.file=/local/prometheus.yml",
-          "--storage.tsdb.path=/data/prometheus/prom-tsdb/",
-          "--web.external-url=http://prometheus.service.home.consul:9090/",
-          "--web.enable-lifecycle",
-        ]
+        image      = "prom/prometheus:v3.10.0"
+        entrypoint = ["/bin/sh", "/local/start.sh"]
         labels {
           group = "prometheus"
         }


### PR DESCRIPTION
## Summary

Fixes the deployment failure from #84 (`{{ file }}` is evaluated before volume mounts are available) and delivers the practical improvements that are actually achievable:

- **`rule_files` now uses a glob** (`/config/monitoring/*_rules.yml`) — new rule files are picked up by `/-/reload` without needing to edit `prometheus.yml`
- **`change_mode=signal/SIGHUP`** on the remote_read template — credential rotation triggers a graceful Prometheus reload instead of a full container restart
- Reverts the `{{ file }}` template approach which broke deployment

Changes to `prometheus.yml` itself (new scrape jobs, etc.) still require `nomad job run`, which is the honest limit without a sidecar.

## Test plan

- [ ] Deploy with `nomad job run nomad/monitoring/prometheus.hcl`
- [ ] Verify Prometheus starts and all rule groups load: `curl http://prometheus.service.home.consul:9090/api/v1/rules`

🤖 Generated with [Claude Code](https://claude.com/claude-code)