### PR TITLE
fix: remove newt from blackbox HTTP probe targets

### DIFF
--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -94,7 +94,6 @@ scrape_configs:
           - http://miniflux.service.home.consul:8080/rss
           - z2m.service.home.consul:8081
           - nomad-botherer.service.home.consul:9112
-          - newt.service.home.consul:2112
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target


### PR DESCRIPTION
## Summary

- `newt.service.home.consul:2112` was listed in the `blackbox-consul-http` scrape job, which probes `/` expecting a 2xx response
- Newt's admin server only serves `/metrics` — `/` returns 404, causing `ConsulServiceDown` to fire continuously
- Newt is already scraped directly via the dedicated `newt` job, so the blackbox probe was redundant

## Test plan

- [ ] Verify `ConsulServiceDown` alert for newt clears after config reload
- [ ] Verify newt metrics still appear in Prometheus via the `newt` scrape job

🤖 Generated with [Claude Code](https://claude.com/claude-code)