### PR TITLE
feat: enable live /-/reload for all prometheus config changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Config files live in `monitoring/` and are mounted into prometheus/alertmanager/
 
 On push to main, the `homelab-webhook` Nomad job (at `nomad/infra/homelab-webhook/`) pulls the repo and POSTs `/-/reload` to prometheus (9090), alertmanager (9093), and blackbox-exporter (9115).
 
-Prometheus's startup script concatenates the gitrepo `prometheus.yml` with a Nomad-rendered `remote_read.yml` into `/local/prometheus.yml`. The `/-/reload` endpoint re-reads this file; rule files are loaded via a glob (`/config/monitoring/*_rules.yml`) so new rule files are picked up by `/-/reload` without modifying `prometheus.yml`. Credential rotations trigger a graceful SIGHUP reload via `change_mode=signal` on the remote_read template. Changes to `prometheus.yml` itself (e.g. new scrape jobs) require a `nomad job run` redeploy.
+Prometheus's startup script concatenates the gitrepo `prometheus.yml` with a Nomad-rendered `remote_read.yml` into `/alloc/prometheus.yml` (the shared allocation directory). A `prometheus_config_watcher` sidecar task polls both source files every 10 seconds; when either changes it re-concatenates and calls `/-/reload`. This means all config changes — new scrape jobs, rule file additions, credential rotations — are picked up by `/-/reload` without a `nomad job run` redeploy. The homelab-webhook triggers `/-/reload` on push to main; the sidecar ensures the reload uses the updated config.
 
 Prometheus requires `--web.enable-lifecycle` to enable `/-/reload`. Alertmanager and blackbox-exporter enable it by default.
 

--- a/nomad/monitoring/prometheus.hcl
+++ b/nomad/monitoring/prometheus.hcl
@@ -26,9 +26,9 @@ job "prometheus" {
       driver = "docker"
 
       # Grafana Cloud remote_read credentials from nomad/jobs/prometheus.
-      # Written to /local/remote_read.yml and concatenated with the gitrepo
-      # prometheus.yml at startup by /local/start.sh.
-      # change_mode=signal sends SIGHUP for a graceful reload on credential rotation.
+      # Written to /alloc/remote_read.yml (shared allocation dir) so the
+      # prometheus_config_watcher sidecar can read it when re-concatenating.
+      # change_mode=noop: the sidecar detects the file change and reloads.
       template {
         data = <<EOH
 remote_read:
@@ -38,22 +38,25 @@ remote_read:
       password: "{{ with nomadVar "nomad/jobs/prometheus" }}{{ .grafana_metrics_read_token }}{{ end }}"
     read_recent: true
 EOH
-        destination = "local/remote_read.yml"
-        change_mode = "signal"
-        change_signal = "SIGHUP"
+        destination = "alloc/remote_read.yml"
+        change_mode = "noop"
       }
 
       # Startup script: concatenate the gitrepo prometheus.yml with the
-      # remote_read section, then exec Prometheus against the combined file.
+      # remote_read section into /alloc/prometheus.yml (shared allocation dir),
+      # then exec Prometheus against the combined file.
+      # The prometheus_config_watcher sidecar re-concatenates and reloads
+      # whenever either source file changes, enabling live /-/reload for all
+      # config changes including new scrape jobs.
       # Rule files use a glob (/config/monitoring/*_rules.yml) so new rule
-      # files are picked up by /-/reload without touching prometheus.yml.
+      # files are also picked up by /-/reload without touching prometheus.yml.
       template {
         data = <<EOH
 #!/bin/sh
 set -e
-cat /config/monitoring/prometheus.yml /local/remote_read.yml > /local/prometheus.yml
+cat /config/monitoring/prometheus.yml /alloc/remote_read.yml > /alloc/prometheus.yml
 exec /bin/prometheus \
-  --config.file=/local/prometheus.yml \
+  --config.file=/alloc/prometheus.yml \
   --storage.tsdb.path=/data/prometheus/prom-tsdb/ \
   --web.external-url=http://prometheus.service.home.consul:9090/ \
   --web.enable-lifecycle
@@ -83,6 +86,37 @@ EOH
         cpu    = 200
         memory = 512
      }
+    }
+
+    # Sidecar: watches prometheus.yml (gitrepo) and remote_read.yml for changes,
+    # re-concatenates into /alloc/prometheus.yml, and calls /-/reload.
+    # This allows any config change to be picked up via /-/reload (triggered
+    # by the homelab-webhook on push to main) without a nomad job run.
+    # Tasks share the allocation directory (/alloc/), so both tasks see the
+    # same /alloc/prometheus.yml and /alloc/remote_read.yml.
+    # Tasks share the group network namespace, so localhost:9090 reaches prometheus.
+    task "prometheus_config_watcher" {
+      driver = "docker"
+
+      lifecycle {
+        hook    = "poststart"
+        sidecar = true
+      }
+
+      config {
+        image      = "alpine:3"
+        entrypoint = ["/bin/sh", "/config/nomad/monitoring/prometheus_watch.sh"]
+      }
+
+      volume_mount {
+        volume      = "gitrepo"
+        destination = "/config"
+      }
+
+      resources {
+        cpu    = 50
+        memory = 32
+      }
     }
 
     network {

--- a/nomad/monitoring/prometheus_watch.sh
+++ b/nomad/monitoring/prometheus_watch.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Watches prometheus.yml (gitrepo) and remote_read.yml (Nomad-rendered) for
+# changes. Re-concatenates both into /alloc/prometheus.yml and calls /-/reload
+# so all config changes are picked up without a nomad job run.
+#
+# Runs as a poststart sidecar in the prometheus task group. Tasks share the
+# allocation directory (/alloc/) and network namespace (localhost:9090).
+
+# Wait for prometheus to be ready before the initial sync.
+sleep 10
+cat /config/monitoring/prometheus.yml /alloc/remote_read.yml > /alloc/prometheus.yml
+wget -q --post-data='' -O- http://localhost:9090/-/reload || true
+
+LAST_HASH=$(md5sum /config/monitoring/prometheus.yml /alloc/remote_read.yml | md5sum | cut -d' ' -f1)
+while true; do
+  sleep 10
+  HASH=$(md5sum /config/monitoring/prometheus.yml /alloc/remote_read.yml | md5sum | cut -d' ' -f1)
+  if [ "$HASH" != "$LAST_HASH" ]; then
+    echo "Config changed, reloading prometheus..."
+    cat /config/monitoring/prometheus.yml /alloc/remote_read.yml > /alloc/prometheus.yml
+    wget -q --post-data='' -O- http://localhost:9090/-/reload
+    LAST_HASH="$HASH"
+  fi
+done


### PR DESCRIPTION
## Summary

- Adds a `prometheus_config_watcher` poststart sidecar task (Alpine) that polls `prometheus.yml` and `remote_read.yml` every 10 seconds and calls `/-/reload` when either changes
- Config files moved from `/local/` to `/alloc/` (shared allocation directory) so both tasks can read/write them; tasks share the group network namespace so the sidecar reaches prometheus at `localhost:9090`
- `remote_read` template destination changed `local/` → `alloc/`, `change_mode` `signal` → `noop` (sidecar handles credential rotation reloads too)
- `watch.sh` lives in the repo at `nomad/monitoring/prometheus_watch.sh` and runs directly from the gitrepo volume, so the script can itself be updated with a git push

Previously, changes to `prometheus.yml` (new scrape jobs etc.) required a `nomad job run` redeploy because `{{ file }}` in Nomad templates is evaluated before CSI volumes are mounted. This approach sidesteps that constraint entirely.

## Test plan

- [ ] `nomad job run nomad/monitoring/prometheus.hcl` — verify both `prometheus_server` and `prometheus_config_watcher` tasks start healthy
- [ ] Check sidecar logs: `nomad alloc logs <allocid> prometheus_config_watcher` — should see initial sync and reload after 10s
- [ ] Make a minor change to `monitoring/prometheus.yml`, push to main, confirm prometheus picks it up within ~15s without a redeploy
- [ ] Verify `nomad alloc logs <allocid> prometheus_config_watcher` shows "Config changed, reloading prometheus..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)