### PR TITLE
fix: replace config-watcher sidecar with in-process supervisor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Config files live in `monitoring/` and are mounted into prometheus/alertmanager/
 
 On push to main, the `homelab-webhook` Nomad job (at `nomad/infra/homelab-webhook/`) pulls the repo and POSTs `/-/reload` to prometheus (9090), alertmanager (9093), and blackbox-exporter (9115).
 
-Prometheus's startup script concatenates the gitrepo `prometheus.yml` with a Nomad-rendered `remote_read.yml` into `/alloc/prometheus.yml` (the shared allocation directory). A `prometheus_config_watcher` sidecar task polls both source files every 10 seconds; when either changes it re-concatenates and calls `/-/reload`. This means all config changes — new scrape jobs, rule file additions, credential rotations — are picked up by `/-/reload` without a `nomad job run` redeploy. The homelab-webhook triggers `/-/reload` on push to main; the sidecar ensures the reload uses the updated config.
+The entrypoint for the prometheus container is `nomad/monitoring/prometheus_watch.sh` (from the gitrepo). It concatenates `prometheus.yml` + a Nomad-rendered `remote_read.yml` into `/local/prometheus.yml`, starts prometheus as a background process, and acts as a supervisor: SIGHUP (sent by Nomad on credential rotation via `change_mode=signal`) triggers an immediate re-concatenate + reload; a polling loop re-concatenates and reloads whenever `prometheus.yml` changes (picked up from the gitrepo after the homelab-webhook pulls on push to main). All config changes are picked up by `/-/reload` without a `nomad job run` redeploy. Rule files use a glob so they are also live-reloadable.
 
 Prometheus requires `--web.enable-lifecycle` to enable `/-/reload`. Alertmanager and blackbox-exporter enable it by default.
 

--- a/nomad/monitoring/prometheus.hcl
+++ b/nomad/monitoring/prometheus.hcl
@@ -26,9 +26,9 @@ job "prometheus" {
       driver = "docker"
 
       # Grafana Cloud remote_read credentials from nomad/jobs/prometheus.
-      # Written to /alloc/remote_read.yml (shared allocation dir) so the
-      # prometheus_config_watcher sidecar can read it when re-concatenating.
-      # change_mode=noop: the sidecar detects the file change and reloads.
+      # Written to /local/remote_read.yml; change_mode=signal sends SIGHUP to
+      # the supervisor script (prometheus_watch.sh, PID 1) on credential
+      # rotation, which re-concatenates and reloads prometheus.
       template {
         data = <<EOH
 remote_read:
@@ -38,36 +38,22 @@ remote_read:
       password: "{{ with nomadVar "nomad/jobs/prometheus" }}{{ .grafana_metrics_read_token }}{{ end }}"
     read_recent: true
 EOH
-        destination = "alloc/remote_read.yml"
-        change_mode = "noop"
+        destination = "local/remote_read.yml"
+        change_mode = "signal"
+        change_signal = "SIGHUP"
       }
 
-      # Startup script: concatenate the gitrepo prometheus.yml with the
-      # remote_read section into /alloc/prometheus.yml (shared allocation dir),
-      # then exec Prometheus against the combined file.
-      # The prometheus_config_watcher sidecar re-concatenates and reloads
-      # whenever either source file changes, enabling live /-/reload for all
-      # config changes including new scrape jobs.
+      # prometheus_watch.sh (from gitrepo) is the entrypoint. It:
+      #   1. Concatenates prometheus.yml + remote_read.yml -> /local/prometheus.yml
+      #   2. Starts prometheus as a background process
+      #   3. On SIGHUP: re-concatenates and reloads (handles credential rotation)
+      #   4. Polls prometheus.yml every 10s: re-concatenates and reloads on change
+      #      (handles pushes to main picked up by the homelab-webhook /-/reload)
       # Rule files use a glob (/config/monitoring/*_rules.yml) so new rule
-      # files are also picked up by /-/reload without touching prometheus.yml.
-      template {
-        data = <<EOH
-#!/bin/sh
-set -e
-cat /config/monitoring/prometheus.yml /alloc/remote_read.yml > /alloc/prometheus.yml
-exec /bin/prometheus \
-  --config.file=/alloc/prometheus.yml \
-  --storage.tsdb.path=/data/prometheus/prom-tsdb/ \
-  --web.external-url=http://prometheus.service.home.consul:9090/ \
-  --web.enable-lifecycle
-EOH
-        destination = "local/start.sh"
-        change_mode = "noop"
-      }
-
+      # files are picked up by /-/reload without touching prometheus.yml.
       config {
         image      = "prom/prometheus:v3.10.0"
-        entrypoint = ["/bin/sh", "/local/start.sh"]
+        entrypoint = ["/bin/sh", "/config/nomad/monitoring/prometheus_watch.sh"]
         labels {
           group = "prometheus"
         }
@@ -86,37 +72,6 @@ EOH
         cpu    = 200
         memory = 512
      }
-    }
-
-    # Sidecar: watches prometheus.yml (gitrepo) and remote_read.yml for changes,
-    # re-concatenates into /alloc/prometheus.yml, and calls /-/reload.
-    # This allows any config change to be picked up via /-/reload (triggered
-    # by the homelab-webhook on push to main) without a nomad job run.
-    # Tasks share the allocation directory (/alloc/), so both tasks see the
-    # same /alloc/prometheus.yml and /alloc/remote_read.yml.
-    # Tasks share the group network namespace, so localhost:9090 reaches prometheus.
-    task "prometheus_config_watcher" {
-      driver = "docker"
-
-      lifecycle {
-        hook    = "poststart"
-        sidecar = true
-      }
-
-      config {
-        image      = "alpine:3"
-        entrypoint = ["/bin/sh", "/config/nomad/monitoring/prometheus_watch.sh"]
-      }
-
-      volume_mount {
-        volume      = "gitrepo"
-        destination = "/config"
-      }
-
-      resources {
-        cpu    = 50
-        memory = 32
-      }
     }
 
     network {

--- a/nomad/monitoring/prometheus_watch.sh
+++ b/nomad/monitoring/prometheus_watch.sh
@@ -1,24 +1,43 @@
 #!/bin/sh
-# Watches prometheus.yml (gitrepo) and remote_read.yml (Nomad-rendered) for
-# changes. Re-concatenates both into /alloc/prometheus.yml and calls /-/reload
-# so all config changes are picked up without a nomad job run.
+# Prometheus supervisor script. Runs inside the prom/prometheus container.
 #
-# Runs as a poststart sidecar in the prometheus task group. Tasks share the
-# allocation directory (/alloc/) and network namespace (localhost:9090).
+# Starts prometheus as a background process and watches for config changes:
+#   - SIGHUP (sent by Nomad when remote_read.yml changes via credential
+#     rotation) triggers an immediate re-concatenate + reload.
+#   - Polling loop detects changes to prometheus.yml from the gitrepo
+#     (updated by the homelab-webhook on push to main) and reloads.
+#
+# Paths:
+#   /config/monitoring/prometheus.yml  -- gitrepo CSI volume (read-only)
+#   /local/remote_read.yml             -- Nomad-rendered Grafana Cloud creds
+#   /local/prometheus.yml              -- combined config, read by prometheus
 
-# Wait for prometheus to be ready before the initial sync.
-sleep 10
-cat /config/monitoring/prometheus.yml /alloc/remote_read.yml > /alloc/prometheus.yml
-wget -q --post-data='' -O- http://localhost:9090/-/reload || true
+cat /config/monitoring/prometheus.yml /local/remote_read.yml > /local/prometheus.yml
 
-LAST_HASH=$(md5sum /config/monitoring/prometheus.yml /alloc/remote_read.yml | md5sum | cut -d' ' -f1)
-while true; do
+/bin/prometheus \
+  --config.file=/local/prometheus.yml \
+  --storage.tsdb.path=/data/prometheus/prom-tsdb/ \
+  --web.external-url=http://prometheus.service.home.consul:9090/ \
+  --web.enable-lifecycle &
+PROM_PID=$!
+
+reload() {
+  echo "Reloading prometheus..."
+  cat /config/monitoring/prometheus.yml /local/remote_read.yml > /local/prometheus.yml
+  kill -HUP "$PROM_PID"
+}
+trap reload HUP
+trap 'kill "$PROM_PID"; wait "$PROM_PID"' TERM INT
+
+LAST_HASH=$(md5sum /config/monitoring/prometheus.yml | cut -d' ' -f1)
+while kill -0 "$PROM_PID" 2>/dev/null; do
   sleep 10
-  HASH=$(md5sum /config/monitoring/prometheus.yml /alloc/remote_read.yml | md5sum | cut -d' ' -f1)
+  HASH=$(md5sum /config/monitoring/prometheus.yml | cut -d' ' -f1)
   if [ "$HASH" != "$LAST_HASH" ]; then
-    echo "Config changed, reloading prometheus..."
-    cat /config/monitoring/prometheus.yml /alloc/remote_read.yml > /alloc/prometheus.yml
-    wget -q --post-data='' -O- http://localhost:9090/-/reload
+    echo "prometheus.yml changed, reloading..."
+    reload
     LAST_HASH="$HASH"
   fi
 done
+
+wait "$PROM_PID"


### PR DESCRIPTION
## Problem

PR #87 introduced a `prometheus_config_watcher` sidecar (Alpine container) that failed with:
```
cat: can't open '/alloc/remote_read.yml': No such file or directory
wget: can't connect to remote host: Connection refused
```

Two root causes:
1. Nomad template `destination = "alloc/remote_read.yml"` resolves relative to the **task directory**, not the shared allocation directory — so the file was never at `/alloc/remote_read.yml` in either container
2. Because `/alloc/prometheus.yml` was never created, prometheus itself crashed on every start (the connection refused was a cascade from that)

## Fix

Replace the sidecar with a supervisor approach. `prometheus_watch.sh` (already in the gitrepo, mounted at `/config`) now runs as PID 1 inside the prometheus container. It:

1. Concatenates `prometheus.yml` + `remote_read.yml` → `/local/prometheus.yml`
2. Starts prometheus as a background process
3. Traps SIGHUP (sent by Nomad `change_mode=signal` on credential rotation) → re-concatenates + `kill -HUP $PROM_PID`
4. Polls `prometheus.yml` every 10s → reloads on hash change

Everything stays in `/local/` (task-specific, always accessible). No cross-task file sharing, no separate container, no `/alloc/` path resolution ambiguity.

## Test plan
- [ ] `nomad job run nomad/monitoring/prometheus.hcl` — single task starts healthy
- [ ] Confirm prometheus loads config: `curl -s prometheus.service.home.consul:9090/api/v1/status/config | grep newt` should return nothing
- [ ] Push a minor change to `monitoring/prometheus.yml` to main — confirm reload within ~15s without redeploy
- [ ] Check logs: `nomad alloc logs <allocid> prometheus_server` — should show `prometheus.yml changed, reloading...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)