### PR TITLE
fix: remove prometheus from webhook reload targets

### DIFF
--- a/nomad/infra/homelab-webhook/webhook.py
+++ b/nomad/infra/homelab-webhook/webhook.py
@@ -18,7 +18,8 @@ WEBHOOK_SECRET = os.environ["GITHUB_WEBHOOK_SECRET"].encode()
 PORT = 9111
 
 RELOAD_TARGETS = [
-    "http://prometheus.service.home.consul:9090/-/reload",
+    # prometheus omitted: prometheus_watch.sh polls the gitrepo and reloads
+    # automatically when prometheus.yml changes, so the webhook reload is redundant.
     "http://prom-alertmanager.service.home.consul:9093/-/reload",
     "http://prom-blackbox-exporter.service.home.consul:9115/-/reload",
 ]


### PR DESCRIPTION
## Summary

- `prometheus_watch.sh` polls the gitrepo every 10s and reloads prometheus automatically when `prometheus.yml` changes, making the webhook's `/-/reload` POST to prometheus redundant
- The webhook reload also fired *before* the supervisor re-concatenated the new config, causing a no-op reload followed by the real one — removing it avoids the misleading double-reload
- alertmanager and blackbox-exporter still reload via the webhook as before

## Test plan
- [ ] Push a change to `monitoring/prometheus.yml` to main — confirm prometheus picks it up within ~15s
- [ ] Confirm alertmanager and blackbox-exporter still reload on push (check webhook logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)