### PR TITLE
fix: remove donkeh, bebop, rocksteady; add rabbitseason as DNS server

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -19,9 +19,9 @@ encrypt Consul cluster gossip traffic and must match across all nodes.
 
 | Group | Hosts | Purpose |
 |---|---|---|
-| `nomadconsul` | picluster2/4/5, duckseason, hedwig, donkeh, bebop, rocksteady | Nomad clients+servers and Consul agents |
+| `nomadconsul` | picluster5, duckseason, hedwig | Nomad clients+servers and Consul agents |
 | `nfs_server` | duckseason, rabbitseason | NFS servers: duckseason exports `/export/things`; rabbitseason exports `/srv` (from `/localssd/srv`) and `/mix` (from `/localdisk/mix`) |
-| `dns_server` | hedwig, donkeh, duckseason | BIND9 with Consul forwarding for `.consul` queries |
+| `dns_server` | hedwig, duckseason | BIND9 with Consul forwarding for `.consul` queries |
 | `ups` | hedwig, duckseason | NUT for UPS monitoring |
 | `login` | rabbitseason | Public-facing SSH login node |
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -21,7 +21,7 @@ encrypt Consul cluster gossip traffic and must match across all nodes.
 |---|---|---|
 | `nomadconsul` | picluster5, duckseason, hedwig | Nomad clients+servers and Consul agents |
 | `nfs_server` | duckseason, rabbitseason | NFS servers: duckseason exports `/export/things`; rabbitseason exports `/srv` (from `/localssd/srv`) and `/mix` (from `/localdisk/mix`) |
-| `dns_server` | hedwig, duckseason | BIND9 with Consul forwarding for `.consul` queries |
+| `dns_server` | hedwig, rabbitseason, duckseason | BIND9 with Consul forwarding for `.consul` queries |
 | `ups` | hedwig, duckseason | NUT for UPS monitoring |
 | `login` | rabbitseason | Public-facing SSH login node |
 

--- a/dns/README.md
+++ b/dns/README.md
@@ -1,6 +1,6 @@
 # dns
 
-BIND9 configuration for the `home.andvari.net` zone, served by hedwig, donkeh, and duckseason.
+BIND9 configuration for the `home.andvari.net` zone, served by hedwig and duckseason.
 
 | File | Purpose |
 |---|---|
@@ -37,4 +37,4 @@ cd ansible
 ansible-playbook -i inventory.yml site.yml --limit dns_server
 ```
 
-DNS servers (from `ansible/inventory.yml`): **hedwig**, **donkeh**, **duckseason**.
+DNS servers (from `ansible/inventory.yml`): **hedwig**, **duckseason**.

--- a/dns/README.md
+++ b/dns/README.md
@@ -1,6 +1,6 @@
 # dns
 
-BIND9 configuration for the `home.andvari.net` zone, served by hedwig and duckseason.
+BIND9 configuration for the `home.andvari.net` zone, served by hedwig, rabbitseason, and duckseason.
 
 | File | Purpose |
 |---|---|
@@ -37,4 +37,4 @@ cd ansible
 ansible-playbook -i inventory.yml site.yml --limit dns_server
 ```
 
-DNS servers (from `ansible/inventory.yml`): **hedwig**, **duckseason**.
+DNS servers (from `ansible/inventory.yml`): **hedwig**, **rabbitseason**, **duckseason**.

--- a/dns/etc-bind/db.100.168.192
+++ b/dns/etc-bind/db.100.168.192
@@ -1,6 +1,6 @@
 $TTL    604800
 @       IN      SOA     home.andvari.net. admin.home.andvari.net. (
-                             21         ; Serial
+                             22         ; Serial
                          604800         ; Refresh
                           86400         ; Retry
                         2419200         ; Expire
@@ -10,9 +10,6 @@ $TTL    604800
 
 ; PTR Records
 245   IN      PTR     picluster5.home.andvari.net.
-247   IN      PTR     bebop.home.andvari.net.
-248   IN      PTR     rocksteady.home.andvari.net.
-249   IN      PTR     donkeh.home.andvari.net.
 250   IN      PTR     hedwig.home.andvari.net.
 251   IN      PTR     rabbitseason.home.andvari.net.
 252   IN      PTR     tings.home.andvari.net.

--- a/dns/etc-bind/db.home.andvari.net
+++ b/dns/etc-bind/db.home.andvari.net
@@ -1,14 +1,13 @@
 $ORIGIN home.andvari.net.
 $TTL    604800
 @       IN      SOA     ns1.home.andvari.net. admin.home.andvari.net. (
-                 53     ; Serial
+                 54     ; Serial
              604800     ; Refresh
               86400     ; Retry
             2419200     ; Expire
              604800 )   ; Negative Cache TTL
 ; name servers - NS records
      IN      NS      ns1.home.andvari.net.
-@    IN      A       192.168.100.249
 @    IN      A       192.168.100.250
 @    IN      A       192.168.100.253
 
@@ -18,9 +17,6 @@ ns1.home.andvari.net.          IN      A       192.168.100.250
 picluster5     IN A 192.168.100.245
 
 ; infra machines and NAS
-bebop          IN A 192.168.100.247
-rocksteady     IN A 192.168.100.248
-donkeh         IN A 192.168.100.249
 hedwig         IN A 192.168.100.250
 rabbitseason   IN A 192.168.100.251
 tings          IN A 192.168.100.252

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -29,9 +29,6 @@ scrape_configs:
           - hedwig
           - rabbitseason
           - duckseason
-          - donkeh
-          - bebop
-          - rocksteady
           - picluster5
           - tings
     relabel_configs:
@@ -144,12 +141,9 @@ scrape_configs:
     honor_labels: true
     static_configs:
       - targets:
-          - bebop:4646
-          - donkeh:4646
           - duckseason:4646
           - hedwig:4646
           - picluster5:4646
-          - rocksteady:4646
     relabel_configs:
       - source_labels: [__address__]
         regex: '([^:]+):\d+'


### PR DESCRIPTION
## Summary

- Remove decommissioned hosts (donkeh, bebop, rocksteady) from prometheus scrape targets, DNS zone files, and docs
- Remove donkeh's zone apex `@ IN A` entry; bump forward and reverse zone serials
- Add rabbitseason to dns_server host lists to match current ansible inventory

## Test plan

- [ ] Verify prometheus no longer scrapes removed hosts
- [ ] Apply DNS zones via ansible and confirm named reloads cleanly on hedwig, rabbitseason, duckseason

🤖 Generated with [Claude Code](https://claude.com/claude-code)