### PR TITLE
feat: migrate volumes from tings to rabbitseason

### DIFF
--- a/nomad/storage/volumes/birdnet.hcl
+++ b/nomad/storage/volumes/birdnet.hcl
@@ -1,7 +1,7 @@
 id = "birdnet" # ID as seen in nomad
 name = "birdnet" # Display name
 type = "csi"
-plugin_id = "tings-srv-nfs" # Needs to match the deployed plugin
+plugin_id = "rabbitseason-srv-nfs"
 
 capability {
   access_mode     = "multi-node-multi-writer"

--- a/nomad/storage/volumes/gitrepo.hcl
+++ b/nomad/storage/volumes/gitrepo.hcl
@@ -1,7 +1,7 @@
-id = "gitrepo" # ID as seen in nomad
-name = "gitrepo" # Display name
+id = "gitrepo"
+name = "gitrepo"
 type = "csi"
-plugin_id = "tings-srv-nfs" # Needs to match the deployed plugin
+plugin_id = "rabbitseason-srv-nfs"
 
 capability {
   access_mode     = "multi-node-multi-writer"

--- a/nomad/storage/volumes/monitoring.hcl
+++ b/nomad/storage/volumes/monitoring.hcl
@@ -1,7 +1,7 @@
-id = "monitoring" # ID as seen in nomad
-name = "Monitoring" # Display name
+id = "monitoring"
+name = "monitoring"
 type = "csi"
-plugin_id = "tings-srv-nfs" # Needs to match the deployed plugin
+plugin_id = "rabbitseason-srv-nfs"
 
 capability {
   access_mode     = "multi-node-multi-writer"

--- a/nomad/storage/volumes/mysql.hcl
+++ b/nomad/storage/volumes/mysql.hcl
@@ -1,7 +1,7 @@
-id = "mysql" # ID as seen in nomad
-name = "MySQL" # Display name
+id = "mysql"
+name = "mysql"
 type = "csi"
-plugin_id = "tings-srv-nfs" # Needs to match the deployed plugin
+plugin_id = "rabbitseason-srv-nfs"
 
 capability {
   access_mode     = "multi-node-multi-writer"


### PR DESCRIPTION
## Summary

- Migrate `birdnet`, `mysql`, `monitoring`, `gitrepo` volumes from `tings-srv-nfs` to `rabbitseason-srv-nfs`
- Normalise display names: `MySQL` → `mysql`, `Monitoring` → `monitoring`
- `jellyfin` remains on `tings-srv-nfs` (not yet migrated)

## Test plan

- [ ] rsync data for each volume from `tings:/srv` to `rabbitseason:/srv` before re-registering
- [ ] Stop dependent jobs, delete + re-register each volume, redeploy jobs
- [ ] Verify prometheus TSDB and alertmanager state intact after monitoring migration
- [ ] Verify homelab-webhook can pull repo after gitrepo migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)