### PR TITLE
feat: migrate native NFS bind mounts to CSI volumes

### DIFF
--- a/nomad/apps/octoprint/octoprint.hcl
+++ b/nomad/apps/octoprint/octoprint.hcl
@@ -1,7 +1,14 @@
 job "octoprint" {
   datacenters = ["home"]
   group "octoprint_servers" {
-   
+
+    volume "octoprint" {
+      type            = "csi"
+      source          = "octoprint"
+      access_mode     = "single-node-writer"
+      attachment_mode = "file-system"
+    }
+
     task "octoprint_server" {
       # picluster5 is attached to the 3d printer.
       constraint {
@@ -11,9 +18,6 @@ job "octoprint" {
       driver = "docker" 
       config {
         image = "octoprint/octoprint:latest"
-        volumes = [
-          "/things/docker/octoprint:/octoprint"
-        ]
         labels {
           group = "octoprint"
         } 
@@ -30,6 +34,10 @@ job "octoprint" {
            container_path = "/dev/video0"
          }
         ]
+      }
+      volume_mount {
+        volume      = "octoprint"
+        destination = "/octoprint"
       }
       env {
         ENABLE_MJPG_STREAMER = "true"

--- a/nomad/infra/mosquitto/mosquitto.hcl
+++ b/nomad/infra/mosquitto/mosquitto.hcl
@@ -7,6 +7,13 @@ job "mosquitto" {
       value = "hedwig"
     }
 
+    volume "mosquitto" {
+      type            = "csi"
+      source          = "mosquitto"
+      access_mode     = "single-node-writer"
+      attachment_mode = "file-system"
+    }
+
     task "mosquitto_server" {
       template {
         data = "{{ with nomadVar \"nomad/jobs/mosquitto\" }}{{ .passwd }}{{ end }}"
@@ -16,16 +23,17 @@ job "mosquitto" {
         name = "mosquitto"
         port = "mqtt"
       }
-      driver = "docker" 
+      driver = "docker"
       config {
-         image = "eclipse-mosquitto:2.0.22"
-         volumes = [
-          "/things/docker/mosquitto:/mosquitto"
-         ]
+        image = "eclipse-mosquitto:2.0.22"
         labels {
           group = "mqtt"
         }
         ports = ["mqtt"]
+      }
+      volume_mount {
+        volume      = "mosquitto"
+        destination = "/mosquitto"
       }
     }
     network {

--- a/nomad/infra/z2m/z2m.hcl
+++ b/nomad/infra/z2m/z2m.hcl
@@ -2,7 +2,14 @@ job "z2m" {
   priority = 100
   datacenters = ["home"]
   group "z2m_servers" {
-   
+
+    volume "z2m" {
+      type            = "csi"
+      source          = "z2m"
+      access_mode     = "single-node-writer"
+      attachment_mode = "file-system"
+    }
+
     task "z2m_server" {
       service {
         name = "z2m"
@@ -20,13 +27,16 @@ job "z2m" {
       config {
         image = "koenkk/zigbee2mqtt:2.9.1"
         volumes = [
-          "/things/docker/z2m:/app/data",
           # udev is needed so the container can detect the Conbee stick's device path.
           "/run/udev:/run/udev:ro",
         ]
         ports = ["z2m"]
         # privileged is required for direct USB/serial device access.
         privileged = true
+      }
+      volume_mount {
+        volume      = "z2m"
+        destination = "/app/data"
       }
       resources {
         cpu    = 100

--- a/nomad/storage/volumes/mosquitto.hcl
+++ b/nomad/storage/volumes/mosquitto.hcl
@@ -1,0 +1,9 @@
+id        = "mosquitto"
+name      = "mosquitto"
+type      = "csi"
+plugin_id = "rabbitseason-srv-nfs"
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}

--- a/nomad/storage/volumes/octoprint.hcl
+++ b/nomad/storage/volumes/octoprint.hcl
@@ -1,0 +1,9 @@
+id        = "octoprint"
+name      = "octoprint"
+type      = "csi"
+plugin_id = "rabbitseason-srv-nfs"
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}

--- a/nomad/storage/volumes/z2m.hcl
+++ b/nomad/storage/volumes/z2m.hcl
@@ -1,0 +1,9 @@
+id        = "z2m"
+name      = "z2m"
+type      = "csi"
+plugin_id = "rabbitseason-srv-nfs"
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}


### PR DESCRIPTION
## Summary

Migrates three jobs from `/things/docker/*` bind mounts to CSI volumes on `rabbitseason-srv-nfs`:

- `mosquitto` → `mosquitto` CSI volume
- `z2m` → `z2m` CSI volume (`/run/udev` device mount retained)
- `octoprint` → `octoprint` CSI volume (device mounts for printer/webcam retained)

Remaining native mounts (`traefik`, `hass`, `postgres` on `/localssd`) are intentionally local to hedwig and not addressed here.

## Test plan

- [ ] For each job: rsync `/things/docker/<job>/` to `rabbitseason:/srv/<job>/`
- [ ] `nomad volume create nomad/storage/volumes/<job>.hcl`
- [ ] Stop job, redeploy, verify data intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)