### PR TITLE
fix: pin all Docker images to specific versions

### DIFF
--- a/nomad/apps/kutt/kutt.hcl
+++ b/nomad/apps/kutt/kutt.hcl
@@ -54,7 +54,7 @@ EOF
       }
 
       config {
-        image = "docker.io/kutt/kutt:latest"
+        image = "docker.io/kutt/kutt:v3.2.3"
         ports = ["kutt"]
       }
 

--- a/nomad/apps/miniflux/miniflux.hcl
+++ b/nomad/apps/miniflux/miniflux.hcl
@@ -26,7 +26,7 @@ EOF
       }
       driver = "docker" 
       config {
-        image = "docker.io/miniflux/miniflux:latest"
+        image = "docker.io/miniflux/miniflux:2.2.18"
         ports = ["miniflux"]
       }
     }

--- a/nomad/apps/octoprint/octoprint.hcl
+++ b/nomad/apps/octoprint/octoprint.hcl
@@ -17,7 +17,7 @@ job "octoprint" {
       }
       driver = "docker" 
       config {
-        image = "octoprint/octoprint:latest"
+        image = "octoprint/octoprint:1.11.7"
         labels {
           group = "octoprint"
         } 

--- a/nomad/infra/homelab-webhook/homelab-webhook.hcl
+++ b/nomad/infra/homelab-webhook/homelab-webhook.hcl
@@ -23,7 +23,7 @@ job "homelab-webhook" {
       driver = "docker"
 
       config {
-        image   = "python:3.12-alpine"
+        image   = "python:3.12.13-alpine"
         command = "/bin/sh"
         args    = ["-c", "apk add --no-cache git su-exec && cp /gitrepo/nomad/infra/homelab-webhook/webhook.py /local/webhook.py && exec su-exec nobody python /local/webhook.py"]
         ports   = ["homelab-webhook"]

--- a/nomad/infra/mysql/mysql.hcl
+++ b/nomad/infra/mysql/mysql.hcl
@@ -25,7 +25,7 @@ job "mysql" {
 
       driver = "docker"
       config {
-        image = "mysql:8.4"
+        image = "mysql:8.4.8"
         ports = ["mysql"]
         labels {
           group = "mysql"

--- a/nomad/infra/newt/newt.hcl
+++ b/nomad/infra/newt/newt.hcl
@@ -12,7 +12,7 @@ job "newt" {
       }
       driver = "docker"
       config {
-        image = "fosrl/newt"
+        image = "fosrl/newt:1.10.4"
         labels {
           group = "newt"
         }

--- a/nomad/infra/postfix-andvari-smarthost/postfix-andvari-smarthost.hcl
+++ b/nomad/infra/postfix-andvari-smarthost/postfix-andvari-smarthost.hcl
@@ -10,7 +10,7 @@ job "postfix-andvari-smarthost" {
       }
       driver = "docker" 
       config {
-        image = "mwader/postfix-relay:latest"
+        image = "mwader/postfix-relay:1.2.9"
         labels {
           group = "postfix-andvari-smarthost"
         }

--- a/nomad/infra/traefik/traefik.hcl
+++ b/nomad/infra/traefik/traefik.hcl
@@ -203,7 +203,7 @@ EOH
       }
 
       config {
-        image = "traefik:v3.3"
+        image = "traefik:v3.6.12"
         ports = ["http", "https", "admin"]
         volumes = [
           "local/traefik.yml:/etc/traefik/traefik.yml",

--- a/nomad/infra/z2m/z2m.hcl
+++ b/nomad/infra/z2m/z2m.hcl
@@ -25,7 +25,7 @@ job "z2m" {
       # 'nobody' keeps the process unprivileged otherwise.
       user = "nobody:dialout"
       config {
-        image = "koenkk/zigbee2mqtt:2.9.1"
+        image = "koenkk/zigbee2mqtt:2.9.2"
         volumes = [
           # udev is needed so the container can detect the Conbee stick's device path.
           "/run/udev:/run/udev:ro",

--- a/nomad/monitoring/prom-alertmanager.hcl
+++ b/nomad/monitoring/prom-alertmanager.hcl
@@ -26,7 +26,7 @@ job "prom-alertmanager" {
       driver = "docker"
 
       config {
-        image = "prom/alertmanager"
+        image = "prom/alertmanager:v0.31.1"
         args = ["--config.file=/config/monitoring/prom-alertmanager.yml",
                 "--storage.path=/data/prom-alertmanager",
                 "--web.external-url=http://prom-alertmanager.service.home.consul:9093/"]

--- a/nomad/monitoring/prom-blackbox-exporter.hcl
+++ b/nomad/monitoring/prom-blackbox-exporter.hcl
@@ -17,7 +17,7 @@ job "prom-blackbox-exporter" {
       }
       driver = "docker" 
       config {
-        image = "prom/blackbox-exporter"
+        image = "prom/blackbox-exporter:v0.28.0"
         args = ["--config.file=/config/monitoring/prom-blackbox-exporter.yml"]
         labels {
           group = "prom-blackbox-exporter"

--- a/nomad/monitoring/prom-consul-exporter.hcl
+++ b/nomad/monitoring/prom-consul-exporter.hcl
@@ -8,7 +8,7 @@ job "prom-consul-exporter" {
       }
       driver = "docker" 
       config {
-        image = "prom/consul-exporter"
+        image = "prom/consul-exporter:v0.13.0"
         args = [
           "--consul.server=consul.service.consul:8500"
         ]

--- a/nomad/monitoring/prometheus.hcl
+++ b/nomad/monitoring/prometheus.hcl
@@ -52,7 +52,7 @@ EOH
       # Rule files use a glob (/config/monitoring/*_rules.yml) so new rule
       # files are picked up by /-/reload without touching prometheus.yml.
       config {
-        image      = "prom/prometheus:v3.10.0"
+        image      = "prom/prometheus:v3.11.0"
         entrypoint = ["/bin/sh", "/config/nomad/monitoring/prometheus_watch.sh"]
         labels {
           group = "prometheus"


### PR DESCRIPTION
## Summary

Pins all floating image tags and updates outdated pinned versions.

**Pinned from latest/untagged:**
| Job | Before | After |
|---|---|---|
| kutt | `latest` | `v3.2.3` |
| octoprint | `latest` | `1.11.7` |
| miniflux | `latest` | `2.2.18` |
| prom-alertmanager | _(untagged)_ | `v0.31.1` |
| prom-blackbox-exporter | _(untagged)_ | `v0.28.0` |
| prom-consul-exporter | _(untagged)_ | `v0.13.0` |
| postfix-andvari-smarthost | `latest` | `1.2.9` |
| newt | _(untagged)_ | `1.10.4` |
| homelab-webhook | `3.12-alpine` | `3.12.13-alpine` |

**Updated pinned versions:**
| Job | Before | After |
|---|---|---|
| prometheus | `v3.10.0` | `v3.11.0` |
| traefik | `v3.3` | `v3.6.12` |
| zigbee2mqtt | `2.9.1` | `2.9.2` |
| mysql | `8.4` | `8.4.8` |

**Not changed:**
- `birdnet-go` remains on `nightly` — no stable image published to registry
- `grafana` remains on `11.4.0` — v12 is a major version jump, deferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)