### PR TITLE
feat: add NomadTaskFlapping alert

### DIFF
--- a/monitoring/nomad_flapping_alerting_rules.yml
+++ b/monitoring/nomad_flapping_alerting_rules.yml
@@ -1,0 +1,16 @@
+"groups":
+- "name": "nomad-flapping"
+  "rules":
+
+  # Fires when a task restarts more than once in a rolling 1-hour window.
+  # nomad_client_allocs_restarts is a per-allocation counter; increase() over
+  # 1h catches repeated crashes without firing on a single one-off restart.
+  - "alert": "NomadTaskFlapping"
+    "annotations":
+      "summary": "{{ $labels.job }}/{{ $labels.task }} is flapping"
+      "description": "{{ $labels.job }}/{{ $labels.task }} on {{ $labels.host }} has restarted {{ $value | humanize }} times in the last hour."
+    "expr": |
+      increase(nomad_client_allocs_restarts[1h]) > 1
+    "for": "5m"
+    "labels":
+      "severity": "warning"


### PR DESCRIPTION
## Summary

Adds a `NomadTaskFlapping` warning alert that fires when a Nomad task restarts more than once in a rolling 1-hour window (sustained for 5 minutes).

Uses `increase(nomad_client_allocs_restarts[1h]) > 1` — fires on repeated crashes without triggering on a single one-off restart.

## Test plan

- [ ] Push to main to trigger webhook reload
- [ ] Verify rule appears in Prometheus UI under nomad-flapping group

🤖 Generated with [Claude Code](https://claude.com/claude-code)