### PR TITLE
fix: remove tings NFS mounts from ansible

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -87,8 +87,6 @@ nomadconsul:
                   - "192.168.100.253"
 
 # All physical hosts that should run node_exporter.
-# tings is scraped by prometheus but is not managed by ansible -- install
-# node_exporter there manually (see ansible/roles/node_exporter/README.md).
 node_exporter:
         children:
                 nomadconsul:

--- a/ansible/roles/nfs_client/meta/main.yml
+++ b/ansible/roles/nfs_client/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: Dave O'Connor
-  description: NFS mounts to tings et. al.
+  description: NFS mounts for cluster nodes.
 
 
   license: BSD-3-Clause

--- a/ansible/roles/nfs_client/tasks/main.yml
+++ b/ansible/roles/nfs_client/tasks/main.yml
@@ -19,17 +19,3 @@
     boot: true
     state: mounted
 
-- name: Create mountpoint /mnt/data
-  ansible.builtin.file:
-    path: '/mnt/data'
-    state: directory
-
-- name: Mount NFS share tings:/data on /mnt/data
-  ansible.posix.mount:
-    path: /mnt/data
-    src: "tings:/data"
-    opts: nofail,noatime,nolock,intr,tcp
-    fstype: nfs
-    boot: true
-    state: mounted
-

--- a/ansible/roles/node_exporter/README.md
+++ b/ansible/roles/node_exporter/README.md
@@ -6,16 +6,6 @@ ensures the service is enabled and running. The exporter listens on port 9100.
 All physical hosts are Debian/Ubuntu-based so the apt package is the simplest
 approach — no binary downloads or architecture detection needed.
 
-## Hosts not managed by Ansible
-
-`tings` is scraped by Prometheus but is not in the Ansible inventory. To
-install node_exporter there manually:
-
-```bash
-sudo apt-get update && sudo apt-get install -y prometheus-node-exporter
-sudo systemctl enable --now prometheus-node-exporter
-```
-
 ## Running the playbook
 
 ```bash


### PR DESCRIPTION
## Summary

- Removes `tings:/data` → `/mnt/data` NFS mount from the `nfs_client` role
- Cleans up all remaining references to `tings` in ansible (inventory comment, role description, node_exporter README)

tings is being turned down; all data previously served from there is now in CSI volumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)