### PR TITLE
chore: spring clean docs and monitoring for decommissioned hosts

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -22,7 +22,7 @@ encrypt Consul cluster gossip traffic and must match across all nodes.
 | `nomadconsul` | picluster5, duckseason, hedwig | Nomad clients+servers and Consul agents |
 | `nfs_server` | duckseason, rabbitseason | NFS servers: duckseason exports `/export/things`; rabbitseason exports `/srv` (from `/localssd/srv`) and `/mix` (from `/localdisk/mix`) |
 | `dns_server` | hedwig, rabbitseason, duckseason | BIND9 with Consul forwarding for `.consul` queries |
-| `ups` | hedwig, duckseason | NUT for UPS monitoring |
+| `ups` | duckseason | NUT for UPS monitoring (duckseason has the locally connected UPS) |
 | `login` | rabbitseason | Public-facing SSH login node |
 
 `nomad_server: true` is set by default for nomadconsul hosts; set it explicitly to

--- a/dns/etc-bind/db.100.168.192
+++ b/dns/etc-bind/db.100.168.192
@@ -1,6 +1,6 @@
 $TTL    604800
 @       IN      SOA     home.andvari.net. admin.home.andvari.net. (
-                             22         ; Serial
+                             23         ; Serial
                          604800         ; Refresh
                           86400         ; Retry
                         2419200         ; Expire
@@ -12,5 +12,4 @@ $TTL    604800
 245   IN      PTR     picluster5.home.andvari.net.
 250   IN      PTR     hedwig.home.andvari.net.
 251   IN      PTR     rabbitseason.home.andvari.net.
-252   IN      PTR     tings.home.andvari.net.
 253   IN      PTR     duckseason.home.andvari.net.

--- a/dns/etc-bind/db.home.andvari.net
+++ b/dns/etc-bind/db.home.andvari.net
@@ -1,7 +1,7 @@
 $ORIGIN home.andvari.net.
 $TTL    604800
 @       IN      SOA     ns1.home.andvari.net. admin.home.andvari.net. (
-                 54     ; Serial
+                 55     ; Serial
              604800     ; Refresh
               86400     ; Retry
             2419200     ; Expire
@@ -19,7 +19,6 @@ picluster5     IN A 192.168.100.245
 ; infra machines and NAS
 hedwig         IN A 192.168.100.250
 rabbitseason   IN A 192.168.100.251
-tings          IN A 192.168.100.252
 duckseason     IN A 192.168.100.253
 
 smtp IN CNAME postfix-andvari-smarthost.service.home.consul.

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -30,7 +30,6 @@ scrape_configs:
           - rabbitseason
           - duckseason
           - picluster5
-          - tings
     relabel_configs:
       - source_labels: [__address__]
         regex: (.+)


### PR DESCRIPTION
## Summary

- Remove `tings` from Prometheus scrape targets (node_exporter + blackbox-ping)
- Remove `tings` DNS records (forward + reverse zones), bump serials
- Fix stale `ups` group in ansible README (only `duckseason` runs NUT; hedwig is *on* a UPS but doesn't manage it)

`donkeh`, `bebop`, and `rocksteady` were already removed in prior commits — nothing left to do for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)