### PR TITLE
feat: add check-databasus-backups.sh script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,7 @@ Utility scripts for operating the homelab cluster.
 | `nomad-diff.sh` | Show a diff of what would change if a Nomad job file were submitted (dry-run helper). |
 | `pg-connect.sh` | Open a psql session to the local postgres instance via its Consul address. |
 | `mysql-connect.sh` | Open a mysql shell to the local mysql instance via its Consul address. |
+| `check-databasus-backups.sh` | List all non-system databases (PostgreSQL + MySQL) and verify each one has a backup in the databasus volume. |
 | `grafana-sm-export-tfvars.py` | Reconstruct `terraform/grafana-sm/terraform.tfvars` from the live Grafana Cloud Synthetic Monitoring API. Run this if you've lost your local tfvars. See `docs/grafana-synthetic-monitoring.md`. |
 
 ## Monitoring validation

--- a/scripts/check-databasus-backups.sh
+++ b/scripts/check-databasus-backups.sh
@@ -35,7 +35,7 @@ MYSQL_DBS=$(mysql -h mysql.service.home.consul -u root --batch --skip-column-nam
 
 # --- Find running databasus alloc ---
 echo "==> Finding databasus allocation..."
-ALLOC_ID=$(nomad alloc list -job databasus -json \
+ALLOC_ID=$(nomad job allocs -json databasus \
     | jq -r '[.[] | select(.ClientStatus == "running")] | .[0].ID')
 
 if [[ "$ALLOC_ID" == "null" || -z "$ALLOC_ID" ]]; then

--- a/scripts/check-databasus-backups.sh
+++ b/scripts/check-databasus-backups.sh
@@ -60,7 +60,7 @@ FAIL=0
 check_db() {
     local engine="$1"
     local db="$2"
-    if echo "$BACKUPS" | grep -q "$db"; then
+    if echo "$BACKUPS" | grep -q "^${db}-"; then
         echo "  [OK]   $engine/$db"
         PASS=$((PASS + 1))
     else

--- a/scripts/check-databasus-backups.sh
+++ b/scripts/check-databasus-backups.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# check-databasus-backups.sh — verify databasus is backing up all databases.
+#
+# Lists all non-system databases in PostgreSQL and MySQL, then checks that
+# each one has at least one backup file in the databasus CSI volume
+# (/databasus-data/backups inside the running alloc).
+#
+# Requires: nomad CLI, psql, mysql, jq
+# Requires: NOMAD_TOKEN set in environment
+# Optional: NOMAD_ADDR (default: http://127.0.0.1:4646)
+
+set -euo pipefail
+
+if [[ -z "${NOMAD_TOKEN:-}" ]]; then
+    echo "ERROR: NOMAD_TOKEN is not set" >&2
+    exit 1
+fi
+
+# --- Credentials ---
+PGPASSWORD=$(nomad var get -out=json nomad/jobs/postgres | jq -r '.Items.pgpassword')
+export PGPASSWORD
+
+MYSQL_PWD=$(nomad var get -out=json nomad/jobs/mysql | jq -r '.Items.root_password')
+export MYSQL_PWD
+
+# --- Databases ---
+echo "==> Listing PostgreSQL databases..."
+PG_DBS=$(psql -h postgres.service.home.consul -U postgres -t -A \
+    -c "SELECT datname FROM pg_database WHERE datistemplate = false AND datname != 'postgres';")
+
+echo "==> Listing MySQL databases..."
+MYSQL_DBS=$(mysql -h mysql.service.home.consul -u root --batch --skip-column-names \
+    -e "SHOW DATABASES;" \
+    | grep -vE '^(information_schema|performance_schema|mysql|sys)$')
+
+# --- Find running databasus alloc ---
+echo "==> Finding databasus allocation..."
+ALLOC_ID=$(nomad alloc list -job databasus -json \
+    | jq -r '[.[] | select(.ClientStatus == "running")] | .[0].ID')
+
+if [[ "$ALLOC_ID" == "null" || -z "$ALLOC_ID" ]]; then
+    echo "ERROR: no running databasus allocation found" >&2
+    exit 1
+fi
+
+echo "    alloc: $ALLOC_ID"
+
+# --- List backup files via exec into the alloc ---
+echo "==> Listing /databasus-data/backups..."
+BACKUPS=$(nomad alloc exec -task databasus "$ALLOC_ID" ls /databasus-data/backups 2>/dev/null || true)
+
+if [[ -z "$BACKUPS" ]]; then
+    echo "WARNING: backup directory is empty or unreadable" >&2
+fi
+
+# --- Check each database has a backup ---
+PASS=0
+FAIL=0
+
+check_db() {
+    local engine="$1"
+    local db="$2"
+    if echo "$BACKUPS" | grep -q "$db"; then
+        echo "  [OK]   $engine/$db"
+        PASS=$((PASS + 1))
+    else
+        echo "  [MISS] $engine/$db — no backup found in /databasus-data/backups"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo ""
+echo "==> PostgreSQL"
+for db in $PG_DBS; do
+    check_db postgres "$db"
+done
+
+echo ""
+echo "==> MySQL"
+for db in $MYSQL_DBS; do
+    check_db mysql "$db"
+done
+
+echo ""
+if [[ $FAIL -gt 0 ]]; then
+    echo "FAIL: $PASS backed up, $FAIL missing"
+    exit 1
+else
+    echo "OK: all $PASS databases have backups"
+fi


### PR DESCRIPTION
## Summary

- Adds `scripts/check-databasus-backups.sh` to verify databasus is backing up all databases
- Queries PostgreSQL and MySQL for non-system databases (same credential pattern as `pg-connect.sh` / `mysql-connect.sh`)
- Finds the running databasus alloc and `ls /databasus-data/backups` via `nomad alloc exec`
- Reports `[OK]` / `[MISS]` per database, exits non-zero if anything is missing
- Updates `scripts/README.md`

## Test plan

- [ ] `NOMAD_TOKEN=... bash scripts/check-databasus-backups.sh` from hedwig

🤖 Generated with [Claude Code](https://claude.com/claude-code)