### PR TITLE
feat: add reservation value and duration to memory over-reservation alert

### DIFF
--- a/monitoring/nomad_resource_alerting_rules.yml
+++ b/monitoring/nomad_resource_alerting_rules.yml
@@ -9,7 +9,8 @@
   - "alert": "NomadJobMemoryOverReservation"
     "annotations":
       "summary": "{{ $labels.job }}/{{ $labels.task }} is over its memory reservation"
-      "description": "{{ $labels.job }}/{{ $labels.task }} on {{ $labels.host }} has been using {{ $value | humanize }}B above its reservation for 5 minutes. Consider raising the memory reservation."
+      "description": |
+        {{ $labels.job }}/{{ $labels.task }} on {{ $labels.host }} has been {{ $value | humanize }}B over its memory reservation{{ with query (printf "nomad_client_allocs_memory_allocated{job=\"%s\",task=\"%s\",host=\"%s\"}" $labels.job $labels.task $labels.host) }} (reservation: {{ . | first | value | humanize }}B){{ end }}, for {{ with query (printf "time() - ALERTS_FOR_STATE{alertname=\"NomadJobMemoryOverReservation\",job=\"%s\",task=\"%s\"}" $labels.job $labels.task) }}{{ . | first | value | humanizeDuration }}{{ end }}. Consider raising the memory reservation.
     "expr": |
       (
         nomad_client_allocs_memory_usage - nomad_client_allocs_memory_allocated


### PR DESCRIPTION
## Summary

- `NomadJobMemoryOverReservation` alert description now includes the actual memory reservation amount, queried at alert time via `nomad_client_allocs_memory_allocated`
- Also includes how long the job has been over reservation, computed as `time() - ALERTS_FOR_STATE{...}` and formatted with `humanizeDuration`

Example output: `myjob/mytask on myhost has been 128MiB over its memory reservation (reservation: 512MiB), for 23m 14s. Consider raising the memory reservation.`

## Test plan

- [x] `bash scripts/check-monitoring-configs.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)