### PR TITLE
feat: reduce Grafana Synthetics quota usage

### DIFF
--- a/terraform/grafana-sm/checks.tf
+++ b/terraform/grafana-sm/checks.tf
@@ -5,9 +5,10 @@ locals {
 resource "grafana_synthetic_monitoring_check" "http" {
   for_each = var.http_checks
 
-  job     = each.key
-  target  = each.value.target
-  enabled = true
+  job       = each.key
+  target    = each.value.target
+  enabled   = true
+  frequency = each.value.frequency
 
   # Resolve probe names to IDs; skip any name not available in this account's probe list.
   probes = [

--- a/terraform/grafana-sm/terraform.tfvars.example
+++ b/terraform/grafana-sm/terraform.tfvars.example
@@ -13,25 +13,25 @@ http_checks = {
 
   # Example: public-facing site that must be reachable from the internet.
   # Alert fires if all probes report failure for 5 minutes.
+  # Defaults: frequency = 600000 (10 min), probes = ["London"]
   "my-public-site" = {
     target             = "https://example.com"
-    probes             = ["Atlanta", "London", "Singapore"]
     valid_status_codes = [200]
   }
 
   # Example: endpoint that must return 200 and contain specific text in the body.
+  # Override frequency to 5 minutes for more critical checks.
   "my-public-site-content-check" = {
     target                          = "https://example.com/health"
-    probes                          = ["Atlanta", "London"]
     valid_status_codes              = [200]
     fail_if_body_not_matches_regexp = ["ok"]
+    frequency                       = 300000  # 5 minutes
   }
 
   # Example: endpoint that redirects on login — check the redirect itself, not the destination.
   # no_follow_redirects stops the probe from following the 302 so valid_status_codes = [302] works.
   "my-redirect-check" = {
     target              = "https://example.com/login"
-    probes              = ["London"]
     valid_status_codes  = [302]
     no_follow_redirects = true
   }
@@ -41,7 +41,6 @@ http_checks = {
   # can reach it (probe_success == 1 for 5 minutes).
   "internal-admin-ui" = {
     target             = "https://admin.example.com"
-    probes             = ["Atlanta", "London", "Singapore"]
     valid_status_codes = [200, 401, 403]
   }
 }

--- a/terraform/grafana-sm/variables.tf
+++ b/terraform/grafana-sm/variables.tf
@@ -36,7 +36,8 @@ logic cannot be driven by label values — only by the job name.
 EOT
   type = map(object({
     target             = string
-    probes             = optional(list(string), ["Atlanta", "Chicago", "London", "Singapore"])
+    probes             = optional(list(string), ["London"])
+    frequency          = optional(number, 600000)  # milliseconds; default 10 minutes
     valid_status_codes = optional(list(number), [200])
 
     # Body matching: regexp patterns. Check fails if body matches any pattern in


### PR DESCRIPTION
- Add configurable frequency (default 10 minutes / 600000ms)
- Change default probe location from 4 sites to London only
- Update examples to reflect new defaults

Reduces check executions from ~240/hour to ~6/hour per endpoint.