### PR TITLE
feat: add immich photo management job

### DIFF
--- a/nomad/apps/README.md
+++ b/nomad/apps/README.md
@@ -9,6 +9,7 @@ User-facing applications.
 | `birdnet` | BirdNET-Go bird call detection | Backed by CSI NFS volume; at `birbs.home.andvari.net` |
 | `cringesweeper` | Sweeps old posts from Bluesky and Mastodon | Secrets in `nomad/jobs/cringesweeper` |
 | `kutt` | URL shortener at go.home.andvari.net | Backed by postgres and CSI NFS volume; secrets in `nomad/jobs/kutt` |
+| `immich` | Self-hosted photo/video management | Dedicated postgres+vectorchord, Redis, ML; photos on mix, DB on srv |
 
 ## Hardware-pinned jobs
 

--- a/nomad/apps/immich/README.md
+++ b/nomad/apps/immich/README.md
@@ -1,0 +1,87 @@
+# immich
+
+[Immich](https://immich.app) — self-hosted photo and video management.
+
+The public hostname is stored in the `nomad/jobs/traefik` variable (not in
+this repo) and is not added to local DNS — it resolves via public DNS to
+Traefik on hedwig.
+
+## Architecture
+
+All four services run as tasks in a single Nomad job group:
+
+| Task | Image | Port |
+|---|---|---|
+| `immich-server` | `ghcr.io/immich-app/immich-server:release` | 2283 |
+| `immich-ml` | `ghcr.io/immich-app/immich-machine-learning:release` | 3003 |
+| `immich-redis` | `redis:7-alpine` | 6379 |
+| `immich-db` | `ghcr.io/immich-app/postgres:16-vectorchord` | 5433 |
+
+Immich requires its own postgres (with the vectorchord extension) — it does
+not use the shared `postgres` job. Port 5433 is used to avoid collision with
+the shared postgres on 5432.
+
+Machine learning runs CPU-only (hedwig has an Intel Iris 6100 iGPU; OpenVINO
+support for Broadwell Gen 8 is limited).
+
+## Storage
+
+| Volume | NFS share | Contents |
+|---|---|---|
+| `immich-photos` | `rabbitseason:/mix` | Photo and video library |
+| `immich-db` | `rabbitseason:/srv` | Postgres data directory |
+
+## First-time setup
+
+### 1. Create the immich Nomad variable
+
+```bash
+nomad var put nomad/jobs/immich \
+  db_password='choose-a-strong-password'
+```
+
+### 2. Add the hostname to the Traefik variable
+
+The Traefik dynamic config reads `immich_hostname` from `nomad/jobs/traefik`.
+Add it while preserving all existing keys:
+
+```bash
+nomad var get -out json nomad/jobs/traefik \
+  | jq '.Items.immich_hostname = "pics.home.andvari.net"' \
+  | nomad var put -in json nomad/jobs/traefik -
+```
+
+Once set, Nomad re-renders Traefik's dynamic config and the route becomes
+active automatically — no Traefik redeploy needed.
+
+### 3. Create the CSI volumes
+
+```bash
+nomad volume create nomad/storage/volumes/immich-photos.hcl
+nomad volume create nomad/storage/volumes/immich-db.hcl
+```
+
+### 4. Deploy
+
+```bash
+nomad job run nomad/apps/immich/immich.hcl
+```
+
+Immich runs database migrations automatically on first start. The initial
+startup takes longer than usual while migrations run and the machine learning
+container downloads its models (~few hundred MB).
+
+## Ongoing operation
+
+```bash
+# Logs
+nomad alloc logs -job immich immich-server
+nomad alloc logs -job immich immich-ml
+nomad alloc logs -job immich immich-db
+
+# Status
+nomad job status immich
+```
+
+The first account registered becomes the admin. After initial setup, external
+registration can be disabled in the Immich admin panel.

--- a/nomad/apps/immich/README.md
+++ b/nomad/apps/immich/README.md
@@ -47,7 +47,7 @@ Add it while preserving all existing keys:
 
 ```bash
 nomad var get -out json nomad/jobs/traefik \
-  | jq '.Items.immich_hostname = "pics.home.andvari.net"' \
+  | jq '.Items.immich_hostname = "<your-hostname>"' \
   | nomad var put -in json nomad/jobs/traefik -
 ```
 

--- a/nomad/apps/immich/README.md
+++ b/nomad/apps/immich/README.md
@@ -15,7 +15,7 @@ All four services run as tasks in a single Nomad job group:
 | `immich-server` | `ghcr.io/immich-app/immich-server:release` | 2283 |
 | `immich-ml` | `ghcr.io/immich-app/immich-machine-learning:release` | 3003 |
 | `immich-redis` | `redis:7-alpine` | 6379 |
-| `immich-db` | `ghcr.io/immich-app/postgres:16-vectorchord` | 5433 |
+| `immich-db` | `ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0` | 5433 |
 
 Immich requires its own postgres (with the vectorchord extension) — it does
 not use the shared `postgres` job. Port 5433 is used to avoid collision with

--- a/nomad/apps/immich/immich.hcl
+++ b/nomad/apps/immich/immich.hcl
@@ -73,6 +73,31 @@ EOF
     }
 
     # -----------------------------------------------------------------------
+    # wait-for-db: ephemeral prestart task — polls pg_isready until postgres
+    # is accepting connections, then exits 0. Main tasks don't start until
+    # all ephemeral prestart tasks have exited successfully.
+    # -----------------------------------------------------------------------
+    task "wait-for-db" {
+      driver = "docker"
+
+      lifecycle {
+        hook    = "prestart"
+        sidecar = false
+      }
+
+      config {
+        image   = "ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0"
+        command = "sh"
+        args    = ["-c", "until pg_isready -h 127.0.0.1 -p 5433 -U immich; do sleep 2; done"]
+      }
+
+      resources {
+        cpu    = 50
+        memory = 64
+      }
+    }
+
+    # -----------------------------------------------------------------------
     # immich-machine-learning: CLIP embeddings + facial recognition (CPU-only)
     # -----------------------------------------------------------------------
     task "immich-ml" {

--- a/nomad/apps/immich/immich.hcl
+++ b/nomad/apps/immich/immich.hcl
@@ -206,7 +206,7 @@ EOF
 
       resources {
         cpu    = 300
-        memory = 512
+        memory = 1024
       }
     }
 

--- a/nomad/apps/immich/immich.hcl
+++ b/nomad/apps/immich/immich.hcl
@@ -43,14 +43,14 @@ job "immich" {
 
       template {
         data = <<EOF
-DB_HOSTNAME=immich-db.service.home.consul
+DB_HOSTNAME=127.0.0.1
 DB_PORT=5433
 DB_USERNAME=immich
 DB_PASSWORD={{ with nomadVar "nomad/jobs/immich" }}{{ .db_password }}{{ end }}
 DB_DATABASE_NAME=immich
-REDIS_HOSTNAME=immich-redis.service.home.consul
+REDIS_HOSTNAME=127.0.0.1
 REDIS_PORT=6379
-IMMICH_MACHINE_LEARNING_URL=http://immich-ml.service.home.consul:3003
+IMMICH_MACHINE_LEARNING_URL=http://127.0.0.1:3003
 EOF
         destination = "secrets/env"
         env         = true

--- a/nomad/apps/immich/immich.hcl
+++ b/nomad/apps/immich/immich.hcl
@@ -101,9 +101,15 @@ EOF
 
     # -----------------------------------------------------------------------
     # immich-redis: job queue and session cache
+    # Prestart sidecar: starts before immich-server and immich-ml.
     # -----------------------------------------------------------------------
     task "immich-redis" {
       driver = "docker"
+
+      lifecycle {
+        hook    = "prestart"
+        sidecar = true
+      }
 
       service {
         name = "immich-redis"
@@ -131,9 +137,15 @@ EOF
     # Uses port 5433 to avoid collision with the shared postgres on 5432.
     # PGDATA is set to a subdirectory to avoid NFS "directory not empty" errors
     # on first initialisation.
+    # Prestart sidecar: starts before immich-server and immich-ml.
     # -----------------------------------------------------------------------
     task "immich-db" {
       driver = "docker"
+
+      lifecycle {
+        hook    = "prestart"
+        sidecar = true
+      }
 
       service {
         name = "immich-db"

--- a/nomad/apps/immich/immich.hcl
+++ b/nomad/apps/immich/immich.hcl
@@ -157,7 +157,7 @@ EOF
       }
 
       config {
-        image = "ghcr.io/immich-app/postgres:16-vectorchord"
+        image = "ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0"
         ports = ["db"]
       }
 

--- a/nomad/apps/immich/immich.hcl
+++ b/nomad/apps/immich/immich.hcl
@@ -188,6 +188,7 @@ POSTGRES_USER=immich
 POSTGRES_PASSWORD={{ with nomadVar "nomad/jobs/immich" }}{{ .db_password }}{{ end }}
 POSTGRES_DB=immich
 PGDATA=/var/lib/postgresql/data/pgdata
+PGPORT=5433
 EOF
         destination = "secrets/env"
         env         = true

--- a/nomad/apps/immich/immich.hcl
+++ b/nomad/apps/immich/immich.hcl
@@ -1,0 +1,183 @@
+job "immich" {
+  datacenters = ["home"]
+
+  group "immich" {
+
+    # Photos library — stored on mix (large media NFS share)
+    volume "immich-photos" {
+      type            = "csi"
+      source          = "immich-photos"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
+    # Postgres data — stored on srv (general NFS share)
+    volume "immich-db" {
+      type            = "csi"
+      source          = "immich-db"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
+    # -----------------------------------------------------------------------
+    # immich-server: main API + web UI
+    # Traefik routing is defined in nomad/infra/traefik/traefik.hcl
+    # (dynamic.yml template), keyed off immich_hostname in nomad/jobs/traefik.
+    # -----------------------------------------------------------------------
+    task "immich-server" {
+      driver = "docker"
+
+      service {
+        name = "immich"
+        port = "http"
+        check {
+          name     = "HTTP Connection Check"
+          type     = "http"
+          path     = "/api/server/ping"
+          interval = "30s"
+          timeout  = "10s"
+        }
+      }
+
+      template {
+        data = <<EOF
+DB_HOSTNAME=immich-db.service.home.consul
+DB_PORT=5433
+DB_USERNAME=immich
+DB_PASSWORD={{ with nomadVar "nomad/jobs/immich" }}{{ .db_password }}{{ end }}
+DB_DATABASE_NAME=immich
+REDIS_HOSTNAME=immich-redis.service.home.consul
+REDIS_PORT=6379
+IMMICH_MACHINE_LEARNING_URL=http://immich-ml.service.home.consul:3003
+EOF
+        destination = "secrets/env"
+        env         = true
+      }
+
+      config {
+        image = "ghcr.io/immich-app/immich-server:release"
+        ports = ["http"]
+      }
+
+      volume_mount {
+        volume      = "immich-photos"
+        destination = "/usr/src/app/upload"
+      }
+
+      resources {
+        cpu    = 500
+        memory = 1024
+      }
+    }
+
+    # -----------------------------------------------------------------------
+    # immich-machine-learning: CLIP embeddings + facial recognition (CPU-only)
+    # -----------------------------------------------------------------------
+    task "immich-ml" {
+      driver = "docker"
+
+      service {
+        name = "immich-ml"
+        port = "ml"
+        check {
+          type     = "tcp"
+          interval = "30s"
+          timeout  = "5s"
+        }
+      }
+
+      config {
+        image = "ghcr.io/immich-app/immich-machine-learning:release"
+        ports = ["ml"]
+      }
+
+      resources {
+        cpu    = 1000
+        memory = 2048
+      }
+    }
+
+    # -----------------------------------------------------------------------
+    # immich-redis: job queue and session cache
+    # -----------------------------------------------------------------------
+    task "immich-redis" {
+      driver = "docker"
+
+      service {
+        name = "immich-redis"
+        port = "redis"
+        check {
+          type     = "tcp"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
+      config {
+        image = "docker.io/redis:7-alpine"
+        ports = ["redis"]
+      }
+
+      resources {
+        cpu    = 100
+        memory = 128
+      }
+    }
+
+    # -----------------------------------------------------------------------
+    # immich-db: dedicated postgres with vectorchord (required by Immich).
+    # Uses port 5433 to avoid collision with the shared postgres on 5432.
+    # PGDATA is set to a subdirectory to avoid NFS "directory not empty" errors
+    # on first initialisation.
+    # -----------------------------------------------------------------------
+    task "immich-db" {
+      driver = "docker"
+
+      service {
+        name = "immich-db"
+        port = "db"
+        check {
+          type     = "tcp"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
+      template {
+        data = <<EOF
+POSTGRES_USER=immich
+POSTGRES_PASSWORD={{ with nomadVar "nomad/jobs/immich" }}{{ .db_password }}{{ end }}
+POSTGRES_DB=immich
+PGDATA=/var/lib/postgresql/data/pgdata
+EOF
+        destination = "secrets/env"
+        env         = true
+      }
+
+      config {
+        image = "ghcr.io/immich-app/postgres:16-vectorchord"
+        ports = ["db"]
+      }
+
+      volume_mount {
+        volume      = "immich-db"
+        destination = "/var/lib/postgresql/data"
+      }
+
+      resources {
+        cpu    = 300
+        memory = 512
+      }
+    }
+
+    network {
+      mode = "host"
+      port "http"  { static = "2283" }
+      port "ml"    { static = "3003" }
+      port "redis" { static = "6379" }
+      port "db"    { static = "5433" }
+    }
+  }
+}

--- a/nomad/apps/immich/immich.hcl
+++ b/nomad/apps/immich/immich.hcl
@@ -43,14 +43,14 @@ job "immich" {
 
       template {
         data = <<EOF
-DB_HOSTNAME=127.0.0.1
-DB_PORT=5433
+DB_HOSTNAME={{ env "NOMAD_IP_db" }}
+DB_PORT={{ env "NOMAD_PORT_db" }}
 DB_USERNAME=immich
 DB_PASSWORD={{ with nomadVar "nomad/jobs/immich" }}{{ .db_password }}{{ end }}
 DB_DATABASE_NAME=immich
-REDIS_HOSTNAME=127.0.0.1
-REDIS_PORT=6379
-IMMICH_MACHINE_LEARNING_URL=http://127.0.0.1:3003
+REDIS_HOSTNAME={{ env "NOMAD_IP_redis" }}
+REDIS_PORT={{ env "NOMAD_PORT_redis" }}
+IMMICH_MACHINE_LEARNING_URL=http://{{ env "NOMAD_IP_ml" }}:{{ env "NOMAD_PORT_ml" }}
 EOF
         destination = "secrets/env"
         env         = true
@@ -88,7 +88,7 @@ EOF
       config {
         image   = "ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0"
         command = "sh"
-        args    = ["-c", "until pg_isready -h 127.0.0.1 -p 5433 -U immich; do sleep 2; done"]
+        args    = ["-c", "until pg_isready -h ${NOMAD_IP_db} -p ${NOMAD_PORT_db} -U immich; do sleep 2; done"]
       }
 
       resources {

--- a/nomad/infra/traefik/traefik.hcl
+++ b/nomad/infra/traefik/traefik.hcl
@@ -171,7 +171,13 @@ http:
         certResolver: le
       middlewares: [internal-only]
       service: grafana
-
+{{ with nomadVar "nomad/jobs/traefik" }}{{ with .immich_hostname }}    immich:
+      rule: "Host(`{{ . }}`)"
+      tls:
+        certResolver: le
+      middlewares: [internal-only]
+      service: immich
+{{ end }}{{ end }}
   services:
     # Consul DNS resolves these to wherever the service is currently running.
     sonarr:
@@ -198,7 +204,11 @@ http:
       loadBalancer:
         servers:
           - url: "http://grafana.service.home.consul:3000"
-EOH
+{{ with nomadVar "nomad/jobs/traefik" }}{{ with .immich_hostname }}    immich:
+      loadBalancer:
+        servers:
+          - url: "http://immich.service.home.consul:2283"
+{{ end }}{{ end }}EOH
         destination = "local/dynamic.yml"
       }
 

--- a/nomad/infra/traefik/traefik.hcl
+++ b/nomad/infra/traefik/traefik.hcl
@@ -208,7 +208,8 @@ http:
       loadBalancer:
         servers:
           - url: "http://immich.service.home.consul:2283"
-{{ end }}{{ end }}EOH
+{{ end }}{{ end }}
+EOH
         destination = "local/dynamic.yml"
       }
 

--- a/nomad/storage/volumes/README.md
+++ b/nomad/storage/volumes/README.md
@@ -15,6 +15,8 @@ capacity, access mode, and NFS mount parameters.
 | `kutt` | kutt job |
 | `media` | Shared media storage |
 | `monitoring` | prometheus (TSDB), alertmanager (state) |
+| `immich-photos` | immich job (photo/video library at `/usr/src/app/upload`) |
+| `immich-db` | immich job (postgres data directory) |
 | `mysql` | mysql job (`/var/lib/mysql`) |
 
 Note: postgres uses a local SSD bind-mount (`/localssd/postgres` on `hedwig`)

--- a/nomad/storage/volumes/immich-db.hcl
+++ b/nomad/storage/volumes/immich-db.hcl
@@ -1,0 +1,9 @@
+id   = "immich-db"
+name = "immich-db"
+type = "csi"
+plugin_id = "rabbitseason-srv-nfs"
+
+capability {
+  access_mode     = "multi-node-multi-writer"
+  attachment_mode = "file-system"
+}

--- a/nomad/storage/volumes/immich-photos.hcl
+++ b/nomad/storage/volumes/immich-photos.hcl
@@ -1,0 +1,9 @@
+id   = "immich-photos"
+name = "immich-photos"
+type = "csi"
+plugin_id = "rabbitseason-mix-nfs"
+
+capability {
+  access_mode     = "multi-node-multi-writer"
+  attachment_mode = "file-system"
+}


### PR DESCRIPTION
## Summary

- Four-task Nomad job (`immich-server`, `immich-machine-learning`, `immich-redis`, `immich-db`) in a single group
- Dedicated postgres using `ghcr.io/immich-app/postgres:16-vectorchord` (vectorchord extension required by Immich) on port 5433, separate from the shared postgres
- Photo library on a new `immich-photos` CSI volume backed by `rabbitseason:/mix`; postgres data on a new `immich-db` CSI volume backed by `rabbitseason:/srv`
- ML container is CPU-only (`release` tag) — hedwig's Intel Iris 6100 (Broadwell Gen 8) has limited OpenVINO support
- Public hostname kept out of the job HCL: Traefik routing is added to the `dynamic.yml` template in `traefik.hcl`, reading `immich_hostname` from `nomad/jobs/traefik` via a `with` guard (omitted from config if unset)

## Pre-deploy checklist

- [ ] `nomad var put nomad/jobs/immich db_password='...'`
- [ ] Patch `nomad/jobs/traefik` to add `immich_hostname` (see `nomad/apps/immich/README.md`)
- [ ] `nomad volume create nomad/storage/volumes/immich-photos.hcl`
- [ ] `nomad volume create nomad/storage/volumes/immich-db.hcl`
- [ ] `nomad job run nomad/infra/traefik/traefik.hcl` (picks up dynamic.yml change)
- [ ] `nomad job run nomad/apps/immich/immich.hcl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)