### PR TITLE
feat: add volume-shell.sh for interactive CSI volume access

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,7 @@ Utility scripts for operating the homelab cluster.
 | `check-databasus-backups.sh` | List all non-system databases (PostgreSQL + MySQL) and verify each one has a backup in the databasus volume. |
 | `grafana-sm-export-tfvars.py` | Reconstruct `terraform/grafana-sm/terraform.tfvars` from the live Grafana Cloud Synthetic Monitoring API. Run this if you've lost your local tfvars. See `docs/grafana-synthetic-monitoring.md`. |
 | `dump-nomad-vars.sh` | Dump all Nomad variables to an AES-256-CBC encrypted bash restore script. Use for disaster-recovery backups; restore by decrypting and piping to bash. See below. |
+| `volume-shell.sh` | Start an interactive shell with a Nomad CSI volume mounted at `/<volume-name>`. Useful for inspecting or modifying volume contents directly. |
 
 ## Nomad variable backup and restore
 

--- a/scripts/volume-shell.sh
+++ b/scripts/volume-shell.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# volume-shell.sh — start an interactive shell with a Nomad CSI volume mounted.
+#
+# Usage: volume-shell.sh <volume-name>
+#
+# Runs a temporary Nomad job that mounts the specified volume at /<volume-name>,
+# then attaches an interactive shell. The job is stopped and purged on exit.
+#
+# Requires: nomad CLI
+# Requires: NOMAD_TOKEN set in environment (or nomad CLI configured with ACL token)
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <volume-name>" >&2
+    exit 1
+fi
+
+VOLUME_NAME="$1"
+JOB_NAME="volume-shell-${VOLUME_NAME}"
+
+cleanup() {
+    echo "Stopping job ${JOB_NAME}..."
+    nomad job stop -purge "${JOB_NAME}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Create temporary job spec
+JOB_SPEC=$(mktemp)
+cat > "${JOB_SPEC}" <<EOF
+job "${JOB_NAME}" {
+  datacenters = ["home"]
+  type        = "batch"
+
+  group "shell" {
+    volume "${VOLUME_NAME}" {
+      type            = "csi"
+      source          = "${VOLUME_NAME}"
+      access_mode     = "multi-node-multi-writer"
+      attachment_mode = "file-system"
+    }
+
+    task "shell" {
+      driver = "docker"
+
+      config {
+        image   = "alpine:latest"
+        command = "/bin/sh"
+        args    = ["-c", "echo 'Volume mounted at /${VOLUME_NAME}. Press Ctrl+D or type exit to quit.' && sleep infinity"]
+        interactive = true
+        tty         = true
+      }
+
+      volume_mount {
+        volume      = "${VOLUME_NAME}"
+        destination = "/${VOLUME_NAME}"
+      }
+
+      resources {
+        cpu    = 100
+        memory = 128
+      }
+    }
+  }
+}
+EOF
+
+echo "Starting job ${JOB_NAME} with volume ${VOLUME_NAME}..."
+nomad job run "${JOB_SPEC}"
+rm -f "${JOB_SPEC}"
+
+# Wait for allocation to be running
+echo "Waiting for allocation to start..."
+for i in {1..30}; do
+    ALLOC_ID=$(nomad job allocs -t '{{range .}}{{if eq .ClientStatus "running"}}{{.ID}}{{end}}{{end}}' "${JOB_NAME}" 2>/dev/null || true)
+    if [[ -n "${ALLOC_ID}" ]]; then
+        break
+    fi
+    sleep 1
+done
+
+if [[ -z "${ALLOC_ID}" ]]; then
+    echo "ERROR: Allocation did not start within 30 seconds" >&2
+    nomad job status "${JOB_NAME}"
+    exit 1
+fi
+
+echo "Attaching to allocation ${ALLOC_ID}..."
+echo "Volume is mounted at /${VOLUME_NAME}"
+echo "---"
+
+nomad alloc exec -i -t "${ALLOC_ID}" /bin/sh


### PR DESCRIPTION
Runs a temporary Nomad job that mounts the specified volume, attaches an interactive shell, and cleans up on exit.

Usage: volume-shell.sh <volume-name>