### PR TITLE
feat: Traefik traffic Grafana dashboard

### DIFF
--- a/monitoring/grafana/dashboards/traefik-traffic.json
+++ b/monitoring/grafana/dashboards/traefik-traffic.json
@@ -1,0 +1,186 @@
+{
+  "title": "Traefik Traffic",
+  "uid": "traefik-traffic",
+  "tags": ["traefik", "traffic"],
+  "schemaVersion": 40,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-3h", "to": "now" },
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "id": 1,
+      "title": "Requests / sec by router",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(traefik_router_requests_total{job=\"traefik\",entrypoint=\"websecure\"}[$__rate_interval])) by (router)",
+          "legendFormat": "{{router}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max", "lastNotNull"] }
+      }
+    },
+    {
+      "id": 2,
+      "title": "HTTP status codes",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 9 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(traefik_router_requests_total{job=\"traefik\",entrypoint=\"websecure\"}[$__rate_interval])) by (code)",
+          "legendFormat": "{{code}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": "^2.*" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": "^3.*" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": "^4.*" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": "^5.*" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max"] }
+      }
+    },
+    {
+      "id": 3,
+      "title": "4xx / 5xx errors by router",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 9 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(traefik_router_requests_total{job=\"traefik\",entrypoint=\"websecure\",code=~\"4..|5..\"}[$__rate_interval])) by (router, code)",
+          "legendFormat": "{{router}} — {{code}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max"] }
+      }
+    },
+    {
+      "id": 4,
+      "title": "P95 request duration by router",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum(rate(traefik_router_request_duration_seconds_bucket{job=\"traefik\",entrypoint=\"websecure\"}[$__rate_interval])) by (router, le))",
+          "legendFormat": "{{router}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max"] }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Request totals by router",
+      "description": "Total requests per router over the selected time range, sorted by volume.",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 27 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sort_desc(sum(increase(traefik_router_requests_total{job=\"traefik\",entrypoint=\"websecure\"}[$__range])) by (router))",
+          "legendFormat": "{{router}}",
+          "refId": "A",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Value" },
+            "properties": [{ "id": "displayName", "value": "Requests" }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "router" },
+            "properties": [{ "id": "displayName", "value": "Router" }]
+          }
+        ]
+      },
+      "options": {
+        "sortBy": [{ "displayName": "Requests", "desc": true }],
+        "footer": { "show": false }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true },
+            "renameByName": {}
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -121,6 +121,12 @@ scrape_configs:
     static_configs:
       - targets: ['nomad-botherer.service.home.consul:9112']
 
+  # Traefik reverse proxy metrics.
+  # Requires metrics.prometheus.entryPoint=traefik in traefik static config.
+  - job_name: traefik
+    static_configs:
+      - targets: ['traefik.service.home.consul:8888']
+
   # Newt tunnel client metrics (built-in Prometheus endpoint).
   - job_name: newt
     static_configs:

--- a/nomad/infra/traefik/traefik.hcl
+++ b/nomad/infra/traefik/traefik.hcl
@@ -109,6 +109,12 @@ api:
 
 ping: {}
 
+metrics:
+  prometheus:
+    entryPoint: traefik
+    addRoutersLabels: true
+    addServicesLabels: true
+
 log:
   level: INFO
 EOH


### PR DESCRIPTION
## Summary

- Enable Prometheus metrics in Traefik's static config, served on the existing admin entrypoint (port 8888). `addRoutersLabels` and `addServicesLabels` are both enabled so metrics are broken down per router and per backend service.
- Add a `traefik` scrape job to `prometheus.yml` targeting `traefik.service.home.consul:8888`
- New `traefik-traffic` Grafana dashboard with five panels:
  - **Requests / sec by router** — timeseries, one line per router
  - **HTTP status codes** — timeseries broken down by code (2xx green, 3xx blue, 4xx orange, 5xx red)
  - **4xx / 5xx errors by router** — timeseries to spot which backend is erroring
  - **P95 request duration by router** — latency percentile per router
  - **Request totals by router** — table sorted by volume for the selected time range

All panels filter to the `websecure` entrypoint (HTTPS) to avoid counting HTTP→HTTPS redirects.

## Deploy order

1. `nomad job run nomad/infra/traefik/traefik.hcl` — picks up the new metrics config
2. Prometheus scrape is live-reloaded automatically on next push to main via the webhook

🤖 Generated with [Claude Code](https://claude.com/claude-code)