### PR TITLE
feat: Traefik traffic Grafana dashboard

### DIFF
--- a/monitoring/grafana/dashboards/traefik-traffic.json
+++ b/monitoring/grafana/dashboards/traefik-traffic.json
@@ -3,7 +3,7 @@
   "uid": "traefik-traffic",
   "tags": ["traefik", "traffic"],
   "schemaVersion": 40,
-  "version": 1,
+  "version": 2,
   "refresh": "1m",
   "time": { "from": "now-3h", "to": "now" },
   "timezone": "browser",
@@ -19,7 +19,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(rate(traefik_router_requests_total{job=\"traefik\",entrypoint=\"websecure\"}[$__rate_interval])) by (router)",
+          "expr": "sum(rate(traefik_router_requests_total{job=\"traefik\"}[$__rate_interval])) by (router)",
           "legendFormat": "{{router}}",
           "refId": "A"
         }
@@ -46,7 +46,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(rate(traefik_router_requests_total{job=\"traefik\",entrypoint=\"websecure\"}[$__rate_interval])) by (code)",
+          "expr": "sum(rate(traefik_router_requests_total{job=\"traefik\"}[$__rate_interval])) by (code)",
           "legendFormat": "{{code}}",
           "refId": "A"
         }
@@ -90,7 +90,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(rate(traefik_router_requests_total{job=\"traefik\",entrypoint=\"websecure\",code=~\"4..|5..\"}[$__rate_interval])) by (router, code)",
+          "expr": "sum(rate(traefik_router_requests_total{job=\"traefik\",code=~\"4..|5..\"}[$__rate_interval])) by (router, code)",
           "legendFormat": "{{router}} — {{code}}",
           "refId": "A"
         }
@@ -117,7 +117,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "histogram_quantile(0.95, sum(rate(traefik_router_request_duration_seconds_bucket{job=\"traefik\",entrypoint=\"websecure\"}[$__rate_interval])) by (router, le))",
+          "expr": "histogram_quantile(0.95, sum(rate(traefik_router_request_duration_seconds_bucket{job=\"traefik\"}[$__rate_interval])) by (router, le))",
           "legendFormat": "{{router}}",
           "refId": "A"
         }
@@ -145,7 +145,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sort_desc(sum(increase(traefik_router_requests_total{job=\"traefik\",entrypoint=\"websecure\"}[$__range])) by (router))",
+          "expr": "sort_desc(sum(increase(traefik_router_requests_total{job=\"traefik\"}[$__range])) by (router))",
           "legendFormat": "{{router}}",
           "refId": "A",
           "instant": true,


### PR DESCRIPTION
## Summary

- Enable Prometheus metrics in Traefik's static config, served on the existing admin entrypoint (port 8888) with router and service label dimensions enabled
- Add a `traefik` scrape job to `prometheus.yml`
- New `traefik-traffic` Grafana dashboard with five panels:
  - **Requests / sec by router** — timeseries, one line per router
  - **HTTP status codes** — breakdown by code (2xx green, 3xx blue, 4xx orange, 5xx red)
  - **4xx / 5xx errors by router** — timeseries to spot which backend is erroring
  - **P95 request duration by router** — latency percentile per router
  - **Request totals by router** — table sorted by volume for the selected time range

## Deploy order

1. `nomad job run nomad/infra/traefik/traefik.hcl` — picks up the new metrics config
2. Push to main triggers Prometheus config reload via webhook

🤖 Generated with [Claude Code](https://claude.com/claude-code)