### PR TITLE
feat: Newt service monitoring (birdnet, kutt, immich)

### DIFF
--- a/monitoring/grafana/dashboards/newt-services.json
+++ b/monitoring/grafana/dashboards/newt-services.json
@@ -1,0 +1,482 @@
+{
+  "title": "Newt Services",
+  "uid": "newt-services",
+  "tags": ["newt", "traefik", "services"],
+  "schemaVersion": 40,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-3h", "to": "now" },
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+
+    {
+      "id": 1,
+      "title": "Tunnel Status",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "newt_online",
+          "legendFormat": "tunnel",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "graphMode": "none",
+        "colorMode": "background",
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "Offline", "color": "red",   "index": 0 },
+                "1": { "text": "Online",  "color": "green", "index": 1 }
+              }
+            }
+          ],
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "value": null, "color": "red" },
+              { "value": 1,    "color": "green" }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+
+    {
+      "id": 2,
+      "title": "Active Proxy Connections",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(newt_proxy_active_connections)",
+          "legendFormat": "connections",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "graphMode": "area",
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "value": null, "color": "green" },
+              { "value": 50,   "color": "yellow" },
+              { "value": 100,  "color": "red" }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+
+    {
+      "id": 3,
+      "title": "Write Drops (5m)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(increase(newt_proxy_write_drops_total[5m]))",
+          "legendFormat": "drops",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "graphMode": "none",
+        "colorMode": "background"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "value": null, "color": "green" },
+              { "value": 1,    "color": "yellow" },
+              { "value": 10,   "color": "red" }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+
+    {
+      "id": 4,
+      "title": "Service Health",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "probe_success{job=\"blackbox-newt-services\"}",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "horizontal",
+        "graphMode": "none",
+        "colorMode": "background",
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "DOWN", "color": "red",   "index": 0 },
+                "1": { "text": "UP",   "color": "green", "index": 1 }
+              }
+            }
+          ],
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "value": null, "color": "red" },
+              { "value": 1,    "color": "green" }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+
+    {
+      "id": 5,
+      "title": "Requests / sec by service",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (router) (rate(traefik_router_requests_total{job=\"traefik\",router=~\"(birdnet|kutt|immich)@consulcatalog\"}[$__rate_interval]))",
+          "legendFormat": "{{router}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max", "lastNotNull"] }
+      }
+    },
+
+    {
+      "id": 6,
+      "title": "HTTP status codes by service",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 13 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (router, code) (rate(traefik_router_requests_total{job=\"traefik\",router=~\"(birdnet|kutt|immich)@consulcatalog\"}[$__rate_interval]))",
+          "legendFormat": "{{router}} — {{code}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*— 2.*" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": ".*— 3.*" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": ".*— 4.*" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": ".*— 5.*" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max"] }
+      }
+    },
+
+    {
+      "id": 7,
+      "title": "4xx / 5xx error rate by service",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 13 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (router, code) (rate(traefik_router_requests_total{job=\"traefik\",router=~\"(birdnet|kutt|immich)@consulcatalog\",code=~\"4..|5..\"}[$__rate_interval]))",
+          "legendFormat": "{{router}} — {{code}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*— 4.*" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": ".*— 5.*" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max"] }
+      }
+    },
+
+    {
+      "id": 8,
+      "title": "P95 request latency by service",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 22 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum by (router, le) (rate(traefik_router_request_duration_seconds_bucket{job=\"traefik\",router=~\"(birdnet|kutt|immich)@consulcatalog\"}[$__rate_interval])))",
+          "legendFormat": "{{router}} p95",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.50, sum by (router, le) (rate(traefik_router_request_duration_seconds_bucket{job=\"traefik\",router=~\"(birdnet|kutt|immich)@consulcatalog\"}[$__rate_interval])))",
+          "legendFormat": "{{router}} p50",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max"] }
+      }
+    },
+
+    {
+      "id": 9,
+      "title": "Tunnel bytes in / out",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 22 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(newt_proxy_bytes_received_total[$__rate_interval]))",
+          "legendFormat": "received",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(newt_proxy_bytes_sent_total[$__rate_interval]))",
+          "legendFormat": "sent",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max", "lastNotNull"] }
+      }
+    },
+
+    {
+      "id": 10,
+      "title": "New proxy connections / sec",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 31 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(newt_proxy_accept_total[$__rate_interval]))",
+          "legendFormat": "connections/s",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    },
+
+    {
+      "id": 11,
+      "title": "Proxy connection duration (P95 / P50)",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 31 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(newt_proxy_connection_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p95",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(newt_proxy_connection_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p50",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    },
+
+    {
+      "id": 12,
+      "title": "Backend probe success",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 40 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "probe_success{job=\"blackbox-newt-services\"}",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bool",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      }
+    },
+
+    {
+      "id": 13,
+      "title": "Backend probe duration",
+      "type": "timeseries",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 40 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "probe_duration_seconds{job=\"blackbox-newt-services\"}",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "min": 0,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max", "lastNotNull"] }
+      }
+    }
+
+  ]
+}

--- a/monitoring/newt_alerting_rules.yml
+++ b/monitoring/newt_alerting_rules.yml
@@ -2,11 +2,42 @@ groups:
 - name: newt
   rules:
 
-  # Fire when a lot of new proxy connections are accepted in a short window.
-  # newt_proxy_accept_total counts every connection accepted through the tunnel,
-  # so a spike here means something is hammering the exposed services.
-  # Threshold: >20 new connections in 5 minutes (sustained for 2m) is unusual
-  # for a personal homelab tunnel — tune this down if you add high-traffic services.
+  # -------------------------------------------------------------------------
+  # Tunnel health
+  # -------------------------------------------------------------------------
+
+  # The Newt client has lost its connection to the Pangolin exit node.
+  # All externally-reachable services (birdnet, kutt, immich) are unreachable
+  # until this recovers.
+  - alert: NewtTunnelOffline
+    expr: newt_online == 0
+    for: 2m
+    labels:
+      severity: critical
+    annotations:
+      summary: "Newt tunnel is offline"
+      description: >
+        The Newt tunnel to the Pangolin exit node has been offline for 2 minutes.
+        Services exposed via Newt (birdnet, kutt, immich) are unreachable externally.
+
+  # Write drops mean the tunnel proxy is filling its send buffer faster than the
+  # far end is draining it — either a slow consumer or brief network hiccup.
+  # More than 10 drops in 5 minutes is worth knowing about.
+  - alert: NewtWriteDropsHigh
+    expr: |
+      sum(increase(newt_proxy_write_drops_total[5m])) > 10
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Newt: proxy write drops increasing"
+      description: >
+        {{ $value | humanize }} write drops in the last 5 minutes. The tunnel is
+        discarding data, likely due to a slow consumer or buffer exhaustion on a
+        tunnelled service.
+
+  # Spike in new connections — possible scan or abuse of an exposed service.
+  # Threshold: >20 new connections in 5 minutes is unusual for a personal homelab.
   - alert: NewtConnectionSpike
     expr: |
       sum(increase(newt_proxy_accept_total[5m])) > 20
@@ -18,3 +49,44 @@ groups:
       description: >
         {{ $value | humanize }} new proxy connections accepted in the last 5 minutes.
         Something may be hammering a tunnelled service.
+
+  # -------------------------------------------------------------------------
+  # HTTP health — via Traefik router metrics
+  # Covers the three services routed through the Newt tunnel.
+  # -------------------------------------------------------------------------
+
+  # >5% of requests to a newt-exposed service are returning 5xx errors.
+  - alert: NewtServiceHTTP5xxHigh
+    expr: |
+      sum by (router) (
+        rate(traefik_router_requests_total{job="traefik",router=~"(birdnet|kutt|immich)@consulcatalog",code=~"5.."}[5m])
+      )
+      /
+      sum by (router) (
+        rate(traefik_router_requests_total{job="traefik",router=~"(birdnet|kutt|immich)@consulcatalog"}[5m])
+      ) > 0.05
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "High HTTP 5xx error rate on {{ $labels.router }}"
+      description: >
+        {{ $labels.router }} is returning {{ $value | humanize }} (ratio) 5xx responses
+        over the last 5 minutes (threshold: 5%). Check the service logs.
+
+  # -------------------------------------------------------------------------
+  # Backend availability — via blackbox probes
+  # Probes hit internal Consul addresses so this fires even if the tunnel is
+  # fine but the application itself has crashed.
+  # -------------------------------------------------------------------------
+
+  - alert: NewtServiceDown
+    expr: probe_success{job="blackbox-newt-services"} == 0
+    for: 3m
+    labels:
+      severity: critical
+    annotations:
+      summary: "Newt service backend is down: {{ $labels.instance }}"
+      description: >
+        {{ $labels.instance }} has failed its HTTP health probe for 3 minutes.
+        The backend application is unhealthy regardless of tunnel status.

--- a/monitoring/newt_alerting_rules.yml
+++ b/monitoring/newt_alerting_rules.yml
@@ -36,20 +36,6 @@ groups:
         discarding data, likely due to a slow consumer or buffer exhaustion on a
         tunnelled service.
 
-  # Spike in new connections — possible scan or abuse of an exposed service.
-  # Threshold: >20 new connections in 5 minutes is unusual for a personal homelab.
-  - alert: NewtConnectionSpike
-    expr: |
-      sum(increase(newt_proxy_accept_total[5m])) > 20
-    for: 2m
-    labels:
-      severity: warning
-    annotations:
-      summary: "Newt: high rate of new tunnel connections"
-      description: >
-        {{ $value | humanize }} new proxy connections accepted in the last 5 minutes.
-        Something may be hammering a tunnelled service.
-
   # -------------------------------------------------------------------------
   # HTTP health — via Traefik router metrics
   # Covers the three services routed through the Newt tunnel.

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -132,6 +132,26 @@ scrape_configs:
     static_configs:
       - targets: ['newt.service.home.consul:2112']
 
+  # HTTP availability probes for services exposed externally via the Newt tunnel.
+  # Probed at their internal Consul addresses so backend health is tracked
+  # independently of the tunnel itself.
+  - job_name: blackbox-newt-services
+    metrics_path: /probe
+    params:
+      module: [http_2xx_internal]
+    static_configs:
+      - targets:
+          - http://birdnet.service.home.consul:8823/
+          - http://kutt.service.home.consul:3000/
+          - http://immich.service.home.consul:2283/api/server/ping
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: prom-blackbox-exporter.service.home.consul:9115
+
   # Nomad client metrics — per-allocation CPU and memory usage.
   # Each client only publishes metrics for allocations running on it, so all
   # clients must be scraped. Requires prometheus_metrics=true in nomad.hcl

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -151,6 +151,12 @@ scrape_configs:
         target_label: instance
       - target_label: __address__
         replacement: prom-blackbox-exporter.service.home.consul:9115
+      # Extract the service short name (birdnet / kutt / immich) from the URL
+      # so dashboard legends stay readable.
+      - source_labels: [__param_target]
+        regex: 'https?://([^.]+)\.service\..*'
+        target_label: service
+        replacement: '$1'
 
   # Nomad client metrics — per-allocation CPU and memory usage.
   # Each client only publishes metrics for allocations running on it, so all

--- a/nomad/apps/immich/immich.hcl
+++ b/nomad/apps/immich/immich.hcl
@@ -67,8 +67,9 @@ EOF
       }
 
       resources {
-        cpu    = 500
-        memory = 1024
+        cpu        = 500
+        memory     = 1024
+        memory_max = 3072
       }
     }
 
@@ -119,8 +120,9 @@ EOF
       }
 
       resources {
-        cpu    = 1000
-        memory = 2048
+        cpu        = 1000
+        memory     = 2048
+        memory_max = 3072
       }
     }
 

--- a/nomad/infra/newt/newt.hcl
+++ b/nomad/infra/newt/newt.hcl
@@ -33,6 +33,9 @@ EOH
         TZ                              = "Europe/Dublin"
         NEWT_METRICS_PROMETHEUS_ENABLED = "true"
         NEWT_ADMIN_ADDR                 = "0.0.0.0:2112"
+        # Counts bytes in a background goroutine rather than inline, reducing
+        # latency on the hot data path while still publishing accurate totals.
+        NEWT_METRICS_ASYNC_BYTES        = "true"
       }
     }
 


### PR DESCRIPTION
## Summary

- Enable async byte metrics in Newt (`NEWT_METRICS_ASYNC_BYTES=true`) for lower hot-path overhead
- Add `blackbox-newt-services` Prometheus scrape job probing birdnet, kutt, and immich at their internal Consul addresses, with a `service` relabel for clean legend names
- Add `memory_max = 3072` burst limit to immich-server and immich-ml tasks
- Replace the single stub alert in `newt_alerting_rules.yml` with four meaningful alerts:
  - `NewtTunnelOffline` (critical): tunnel offline >2m
  - `NewtWriteDropsHigh` (warning): >10 proxy write drops in 5m
  - `NewtServiceHTTP5xxHigh` (warning): >5% 5xx on any of the three Traefik routers
  - `NewtServiceDown` (critical): backend HTTP probe failing >3m
- Add `monitoring/grafana/dashboards/newt-services.json` — 13-panel dashboard covering tunnel health stats, requests/sec, HTTP status codes, 4xx/5xx error rates, P95/P50 latency, bytes in/out, connection rates, and backend probe availability

## Test plan

- [ ] `bash scripts/check-monitoring-configs.sh` passes (already verified locally)
- [ ] CI monitoring validation passes on this PR
- [ ] After merge and webhook pull: Prometheus scrapes `blackbox-newt-services` and `newt` jobs without errors
- [ ] Grafana shows "Newt Services" dashboard in the Homelab folder
- [ ] Stat row shows tunnel online and services UP if everything is healthy
- [ ] Deploy updated newt job: `nomad job run nomad/infra/newt/newt.hcl`
- [ ] Deploy updated immich job: `nomad job run nomad/apps/immich/immich.hcl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)