### PR TITLE
feat: paperless-ngx document management

### DIFF
--- a/nomad/apps/README.md
+++ b/nomad/apps/README.md
@@ -10,6 +10,7 @@ User-facing applications.
 | `cringesweeper` | Sweeps old posts from Bluesky and Mastodon | Secrets in `nomad/jobs/cringesweeper` |
 | `kutt` | URL shortener at go.home.andvari.net | Backed by postgres and CSI NFS volume; secrets in `nomad/jobs/kutt` |
 | `immich` | Self-hosted photo/video management | Dedicated postgres+vectorchord, Redis, ML; photos on mix, DB on srv |
+| `paperless` | Document management (paperless-ngx) | Shared postgres, Redis + Gotenberg + Tika sidecars; media/consume/export on mix, index on srv |
 
 ## Hardware-pinned jobs
 

--- a/nomad/apps/paperless/README.md
+++ b/nomad/apps/paperless/README.md
@@ -12,7 +12,7 @@ All four services run as tasks in a single Nomad job group:
 |---|---|---|---|
 | `paperless-webserver` | `paperlessngx/paperless-ngx:2.20.13` | 8000 | Web UI, API, background consumer |
 | `paperless-redis` | `redis:7-alpine` | 6380 | Task queue and job broker |
-| `paperless-gotenberg` | `gotenberg/gotenberg:8.10.1` | 3001 | Office doc → PDF conversion |
+| `paperless-gotenberg` | `gotenberg/gotenberg:8.30.1` | 3001 | Office doc → PDF conversion |
 | `paperless-tika` | `apache/tika:3.0.0.0` | 9998 | Content extraction from Office/email |
 
 Redis, Gotenberg, and Tika are prestart sidecars — they start before the webserver and keep running alongside it.

--- a/nomad/apps/paperless/README.md
+++ b/nomad/apps/paperless/README.md
@@ -1,0 +1,133 @@
+# paperless
+
+[Paperless-ngx](https://docs.paperless-ngx.com/) — self-hosted document management with OCR.
+
+Served at the hostname stored in `nomad/jobs/traefik` → `paperless_hostname` (publicly accessible, no `internal-only` middleware).
+
+## Architecture
+
+All four services run as tasks in a single Nomad job group:
+
+| Task | Image | Port | Role |
+|---|---|---|---|
+| `paperless-webserver` | `paperlessngx/paperless-ngx:2.20.13` | 8000 | Web UI, API, background consumer |
+| `paperless-redis` | `redis:7-alpine` | 6380 | Task queue and job broker |
+| `paperless-gotenberg` | `gotenberg/gotenberg:8.10.1` | 3001 | Office doc → PDF conversion |
+| `paperless-tika` | `apache/tika:3.0.0.0` | 9998 | Content extraction from Office/email |
+
+Redis, Gotenberg, and Tika are prestart sidecars — they start before the webserver and keep running alongside it.
+
+Uses the shared `postgres` job (no special extensions required).
+
+## Storage
+
+| Volume | NFS share | Mount | Contents |
+|---|---|---|---|
+| `paperless-data` | `rabbitseason:/srv` | `/data` | Search index, application state |
+| `paperless-media` | `rabbitseason:/mix` | `/media` | Stored documents and thumbnails |
+| `paperless-consume` | `rabbitseason:/mix` | `/consume` | Input directory (drop files here) |
+| `paperless-export` | `rabbitseason:/mix` | `/export` | Backup exports |
+
+The consume directory is on NFS, so `inotify` is not used — paperless polls every 60 seconds (`PAPERLESS_CONSUMER_POLLING=60`). Documents dropped into the consume volume are picked up within a minute.
+
+## First-time setup
+
+### 1. Create the postgres database and user
+
+```bash
+bash scripts/pg-connect.sh
+```
+
+```sql
+CREATE USER paperless WITH PASSWORD 'choose-a-strong-password';
+CREATE DATABASE paperless OWNER paperless;
+```
+
+### 2. Create the Nomad variable for paperless
+
+Generate a secret key:
+
+```bash
+openssl rand -base64 48
+```
+
+```bash
+nomad var put nomad/jobs/paperless \
+  db_password='the-password-from-above' \
+  secret_key='the-generated-key' \
+  admin_user='admin' \
+  admin_password='choose-a-strong-password'
+```
+
+### 3. Add the hostname to the Traefik variable
+
+This controls both the Traefik routing rule and the `PAPERLESS_URL` / CSRF settings injected into the container:
+
+```bash
+nomad var get -out json nomad/jobs/traefik \
+  | jq '.Items.paperless_hostname = "<your-hostname>"' \
+  | nomad var put -in json nomad/jobs/traefik -
+```
+
+### 4. Add a public DNS A record
+
+Point `<your-hostname>` at Traefik (hedwig, port 443) in your external DNS provider. No entry is needed in the internal BIND9 zone — internal clients resolve via public DNS, which also reaches Traefik directly.
+
+### 5. Create the CSI volumes
+
+```bash
+nomad volume create nomad/storage/volumes/paperless-data.hcl
+nomad volume create nomad/storage/volumes/paperless-media.hcl
+nomad volume create nomad/storage/volumes/paperless-consume.hcl
+nomad volume create nomad/storage/volumes/paperless-export.hcl
+```
+
+### 6. Redeploy Traefik
+
+The Traefik dynamic config is re-rendered by Nomad when the variable changes, but redeploying ensures the new route is active immediately:
+
+```bash
+nomad job run nomad/infra/traefik/traefik.hcl
+```
+
+### 7. Deploy paperless
+
+```bash
+nomad job run nomad/apps/paperless/paperless.hcl
+```
+
+Paperless runs database migrations automatically on first start. First startup is slower than usual.
+
+### 8. Log in
+
+Navigate to `https://<your-hostname>` and log in with the `admin_user` and `admin_password` you set in step 2. The admin account is created automatically from the Nomad variable — no further setup is needed in the UI.
+
+## NFS permissions
+
+Paperless runs as the internal `paperless` user (UID 1000 by default). If the NFS volumes are owned by a different UID, the consumer will fail to delete files after processing them. Fix by setting `USERMAP_UID` and `USERMAP_GID` in the job's env template to match the owning UID/GID on the NFS server.
+
+## Ongoing operation
+
+```bash
+# Logs
+nomad alloc logs -job paperless paperless-webserver
+nomad alloc logs -job paperless paperless-redis
+nomad alloc logs -job paperless paperless-gotenberg
+nomad alloc logs -job paperless paperless-tika
+
+# Status
+nomad job status paperless
+```
+
+### Exporting documents (backup)
+
+```bash
+nomad alloc exec -job paperless -task paperless-webserver \
+  document_exporter /export
+```
+
+Files are written to the `paperless-export` CSI volume on mix.
+
+### Consuming documents manually
+
+Drop files into the `paperless-consume` CSI volume (mounted at `/consume` inside the container). They will be picked up within 60 seconds. Supported formats: PDF, PNG, JPG, TIFF, and (with Tika+Gotenberg) DOCX, XLSX, PPTX, EML, and more.

--- a/nomad/apps/paperless/README.md
+++ b/nomad/apps/paperless/README.md
@@ -56,18 +56,26 @@ nomad var put nomad/jobs/paperless \
   db_password='the-password-from-above' \
   secret_key='the-generated-key' \
   admin_user='admin' \
-  admin_password='choose-a-strong-password'
+  admin_password='choose-a-strong-password' \
+  hostname='<your-hostname>'
 ```
+
+The `hostname` key is used to set `PAPERLESS_URL`, `PAPERLESS_ALLOWED_HOSTS`, and
+`PAPERLESS_CSRF_TRUSTED_ORIGINS` inside the container. The paperless job reads its
+own variable only — it does not have access to `nomad/jobs/traefik`.
 
 ### 3. Add the hostname to the Traefik variable
 
-This controls both the Traefik routing rule and the `PAPERLESS_URL` / CSRF settings injected into the container:
+This controls the Traefik routing rule:
 
 ```bash
 nomad var get -out json nomad/jobs/traefik \
   | jq '.Items.paperless_hostname = "<your-hostname>"' \
   | nomad var put -in json nomad/jobs/traefik -
 ```
+
+The hostname must be set in both variables — `nomad/jobs/paperless` for the app
+config and `nomad/jobs/traefik` for the router rule.
 
 ### 4. Add a public DNS A record
 

--- a/nomad/apps/paperless/paperless.hcl
+++ b/nomad/apps/paperless/paperless.hcl
@@ -99,7 +99,7 @@ job "paperless" {
       }
 
       config {
-        image = "docker.io/gotenberg/gotenberg:8.10.1"
+        image = "docker.io/gotenberg/gotenberg:8.30.1"
         ports = ["gotenberg"]
         # JS disabled for security; allow-list restricts filesystem access.
         # Non-default port to avoid colliding with kutt (3000).

--- a/nomad/apps/paperless/paperless.hcl
+++ b/nomad/apps/paperless/paperless.hcl
@@ -190,10 +190,10 @@ PAPERLESS_DBPORT=5432
 PAPERLESS_DBNAME=paperless
 PAPERLESS_DBUSER=paperless
 PAPERLESS_DBSSLMODE=disable
-PAPERLESS_REDIS=redis://127.0.0.1:6380
+PAPERLESS_REDIS=redis://{{ env "NOMAD_IP_redis" }}:{{ env "NOMAD_PORT_redis" }}
 PAPERLESS_TIKA_ENABLED=true
-PAPERLESS_TIKA_ENDPOINT=http://127.0.0.1:9998
-PAPERLESS_TIKA_GOTENBERG_ENDPOINT=http://127.0.0.1:3001
+PAPERLESS_TIKA_ENDPOINT=http://{{ env "NOMAD_IP_tika" }}:{{ env "NOMAD_PORT_tika" }}
+PAPERLESS_TIKA_GOTENBERG_ENDPOINT=http://{{ env "NOMAD_IP_gotenberg" }}:{{ env "NOMAD_PORT_gotenberg" }}
 PAPERLESS_TIME_ZONE=Europe/Dublin
 PAPERLESS_OCR_LANGUAGE=eng
 # inotify doesn't work over NFS; poll every 60 seconds instead.

--- a/nomad/apps/paperless/paperless.hcl
+++ b/nomad/apps/paperless/paperless.hcl
@@ -99,11 +99,14 @@ job "paperless" {
       }
 
       config {
-        image = "docker.io/gotenberg/gotenberg:8.30.1"
-        ports = ["gotenberg"]
+        image   = "docker.io/gotenberg/gotenberg:8.30.1"
+        ports   = ["gotenberg"]
+        # gotenberg image uses tini as its entrypoint; command must be set so
+        # tini receives "gotenberg" as the executable, not the first flag.
         # JS disabled for security; allow-list restricts filesystem access.
         # Non-default port to avoid colliding with kutt (3000).
-        args  = [
+        command = "gotenberg"
+        args    = [
           "--chromium-disable-javascript=true",
           "--chromium-allow-list=file:///tmp/.*",
           "--api-port=3001",

--- a/nomad/apps/paperless/paperless.hcl
+++ b/nomad/apps/paperless/paperless.hcl
@@ -155,6 +155,8 @@ job "paperless" {
     # paperless-webserver: main web UI, REST API, and background consumer.
     # Hostname-based Traefik route defined in nomad/infra/traefik/traefik.hcl
     # (dynamic.yml template), keyed off paperless_hostname in nomad/jobs/traefik.
+    # The hostname is also stored in nomad/jobs/paperless so this job can read
+    # it without needing access to the traefik variable.
     # Publicly accessible — no internal-only middleware.
     # -----------------------------------------------------------------------
     task "paperless-webserver" {
@@ -178,12 +180,10 @@ PAPERLESS_DBPASS={{ .db_password }}
 PAPERLESS_SECRET_KEY={{ .secret_key }}
 PAPERLESS_ADMIN_USER={{ .admin_user }}
 PAPERLESS_ADMIN_PASSWORD={{ .admin_password }}
+PAPERLESS_URL=https://{{ .hostname }}
+PAPERLESS_ALLOWED_HOSTS={{ .hostname }},localhost
+PAPERLESS_CSRF_TRUSTED_ORIGINS=https://{{ .hostname }}
 {{- end }}
-{{- with nomadVar "nomad/jobs/traefik" }}{{ with .paperless_hostname }}
-PAPERLESS_URL=https://{{ . }}
-PAPERLESS_ALLOWED_HOSTS={{ . }},localhost
-PAPERLESS_CSRF_TRUSTED_ORIGINS=https://{{ . }}
-{{- end }}{{ end }}
 PAPERLESS_DBENGINE=postgresql
 PAPERLESS_DBHOST=postgres.service.home.consul
 PAPERLESS_DBPORT=5432

--- a/nomad/apps/paperless/paperless.hcl
+++ b/nomad/apps/paperless/paperless.hcl
@@ -1,0 +1,250 @@
+job "paperless" {
+  datacenters = ["home"]
+
+  group "paperless" {
+
+    # Search index and application state — fast storage on srv.
+    volume "paperless-data" {
+      type            = "csi"
+      source          = "paperless-data"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
+    # Document library and thumbnails — bulk storage on mix.
+    volume "paperless-media" {
+      type            = "csi"
+      source          = "paperless-media"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
+    # Consume (input) directory — watched for incoming documents.
+    # On NFS, polling is used instead of inotify (see PAPERLESS_CONSUMER_POLLING).
+    volume "paperless-consume" {
+      type            = "csi"
+      source          = "paperless-consume"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
+    # Export directory — destination for paperless-manage document_exporter.
+    volume "paperless-export" {
+      type            = "csi"
+      source          = "paperless-export"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
+    # -----------------------------------------------------------------------
+    # paperless-redis: task queue and background job broker.
+    # Prestart sidecar: the webserver refuses to start without a Redis connection.
+    # -----------------------------------------------------------------------
+    task "paperless-redis" {
+      driver = "docker"
+
+      lifecycle {
+        hook    = "prestart"
+        sidecar = true
+      }
+
+      service {
+        name = "paperless-redis"
+        port = "redis"
+        check {
+          type     = "tcp"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
+      config {
+        image = "docker.io/redis:7-alpine"
+        ports = ["redis"]
+        # Listen on the non-default port so this doesn't collide with
+        # immich-redis (6379) if both jobs land on the same host.
+        args  = ["--port", "6380"]
+      }
+
+      resources {
+        cpu    = 100
+        memory = 128
+      }
+    }
+
+    # -----------------------------------------------------------------------
+    # paperless-gotenberg: converts Office documents and emails to PDF.
+    # Prestart sidecar so it is ready before the consumer starts processing.
+    # -----------------------------------------------------------------------
+    task "paperless-gotenberg" {
+      driver = "docker"
+
+      lifecycle {
+        hook    = "prestart"
+        sidecar = true
+      }
+
+      service {
+        name = "paperless-gotenberg"
+        port = "gotenberg"
+        check {
+          type     = "tcp"
+          interval = "15s"
+          timeout  = "5s"
+        }
+      }
+
+      config {
+        image = "docker.io/gotenberg/gotenberg:8.10.1"
+        ports = ["gotenberg"]
+        # JS disabled for security; allow-list restricts filesystem access.
+        # Non-default port to avoid colliding with kutt (3000).
+        args  = [
+          "--chromium-disable-javascript=true",
+          "--chromium-allow-list=file:///tmp/.*",
+          "--api-port=3001",
+        ]
+      }
+
+      resources {
+        cpu    = 200
+        memory = 256
+      }
+    }
+
+    # -----------------------------------------------------------------------
+    # paperless-tika: content extraction for Office docs and email attachments.
+    # Prestart sidecar so it is ready before the consumer starts processing.
+    # Java-based — needs more memory than the other sidecars.
+    # -----------------------------------------------------------------------
+    task "paperless-tika" {
+      driver = "docker"
+
+      lifecycle {
+        hook    = "prestart"
+        sidecar = true
+      }
+
+      service {
+        name = "paperless-tika"
+        port = "tika"
+        check {
+          type     = "tcp"
+          interval = "15s"
+          timeout  = "5s"
+        }
+      }
+
+      config {
+        image = "docker.io/apache/tika:3.0.0.0"
+        ports = ["tika"]
+      }
+
+      resources {
+        cpu        = 200
+        memory     = 512
+        memory_max = 1024
+      }
+    }
+
+    # -----------------------------------------------------------------------
+    # paperless-webserver: main web UI, REST API, and background consumer.
+    # Hostname-based Traefik route defined in nomad/infra/traefik/traefik.hcl
+    # (dynamic.yml template), keyed off paperless_hostname in nomad/jobs/traefik.
+    # Publicly accessible — no internal-only middleware.
+    # -----------------------------------------------------------------------
+    task "paperless-webserver" {
+      driver = "docker"
+
+      service {
+        name = "paperless"
+        port = "http"
+        check {
+          name     = "TCP Connection Check"
+          type     = "tcp"
+          interval = "30s"
+          timeout  = "5s"
+        }
+      }
+
+      template {
+        data = <<EOF
+{{- with nomadVar "nomad/jobs/paperless" }}
+PAPERLESS_DBPASS={{ .db_password }}
+PAPERLESS_SECRET_KEY={{ .secret_key }}
+PAPERLESS_ADMIN_USER={{ .admin_user }}
+PAPERLESS_ADMIN_PASSWORD={{ .admin_password }}
+{{- end }}
+{{- with nomadVar "nomad/jobs/traefik" }}{{ with .paperless_hostname }}
+PAPERLESS_URL=https://{{ . }}
+PAPERLESS_ALLOWED_HOSTS={{ . }},localhost
+PAPERLESS_CSRF_TRUSTED_ORIGINS=https://{{ . }}
+{{- end }}{{ end }}
+PAPERLESS_DBENGINE=postgresql
+PAPERLESS_DBHOST=postgres.service.home.consul
+PAPERLESS_DBPORT=5432
+PAPERLESS_DBNAME=paperless
+PAPERLESS_DBUSER=paperless
+PAPERLESS_DBSSLMODE=disable
+PAPERLESS_REDIS=redis://127.0.0.1:6380
+PAPERLESS_TIKA_ENABLED=true
+PAPERLESS_TIKA_ENDPOINT=http://127.0.0.1:9998
+PAPERLESS_TIKA_GOTENBERG_ENDPOINT=http://127.0.0.1:3001
+PAPERLESS_TIME_ZONE=Europe/Dublin
+PAPERLESS_OCR_LANGUAGE=eng
+# inotify doesn't work over NFS; poll every 60 seconds instead.
+PAPERLESS_CONSUMER_POLLING=60
+PAPERLESS_CONSUMPTION_DIR=/consume
+PAPERLESS_MEDIA_ROOT=/media
+PAPERLESS_DATA_DIR=/data
+PAPERLESS_EXPORT_DIR=/export
+EOF
+        destination = "secrets/env"
+        env         = true
+      }
+
+      config {
+        image = "docker.io/paperlessngx/paperless-ngx:2.20.13"
+        ports = ["http"]
+      }
+
+      volume_mount {
+        volume      = "paperless-data"
+        destination = "/data"
+      }
+
+      volume_mount {
+        volume      = "paperless-media"
+        destination = "/media"
+      }
+
+      volume_mount {
+        volume      = "paperless-consume"
+        destination = "/consume"
+      }
+
+      volume_mount {
+        volume      = "paperless-export"
+        destination = "/export"
+      }
+
+      resources {
+        cpu        = 500
+        memory     = 1024
+        memory_max = 2048
+      }
+    }
+
+    network {
+      mode = "host"
+      port "http"      { static = 8000 }
+      port "redis"     { static = 6380 }
+      port "gotenberg" { static = 3001 }
+      port "tika"      { static = 9998 }
+    }
+  }
+}

--- a/nomad/infra/traefik/traefik.hcl
+++ b/nomad/infra/traefik/traefik.hcl
@@ -183,6 +183,11 @@ http:
         certResolver: le
       middlewares: [internal-only]
       service: immich
+{{ end }}{{ end }}{{ with nomadVar "nomad/jobs/traefik" }}{{ with .paperless_hostname }}    paperless:
+      rule: "Host(`{{ . }}`)"
+      tls:
+        certResolver: le
+      service: paperless
 {{ end }}{{ end }}
   services:
     # Consul DNS resolves these to wherever the service is currently running.
@@ -214,6 +219,10 @@ http:
       loadBalancer:
         servers:
           - url: "http://immich.service.home.consul:2283"
+{{ end }}{{ end }}{{ with nomadVar "nomad/jobs/traefik" }}{{ with .paperless_hostname }}    paperless:
+      loadBalancer:
+        servers:
+          - url: "http://paperless.service.home.consul:8000"
 {{ end }}{{ end }}
 EOH
         destination = "local/dynamic.yml"

--- a/nomad/storage/volumes/paperless-consume.hcl
+++ b/nomad/storage/volumes/paperless-consume.hcl
@@ -1,0 +1,9 @@
+id        = "paperless-consume"
+name      = "paperless-consume"
+type      = "csi"
+plugin_id = "rabbitseason-mix-nfs"
+
+capability {
+  access_mode     = "multi-node-multi-writer"
+  attachment_mode = "file-system"
+}

--- a/nomad/storage/volumes/paperless-data.hcl
+++ b/nomad/storage/volumes/paperless-data.hcl
@@ -1,0 +1,9 @@
+id        = "paperless-data"
+name      = "paperless-data"
+type      = "csi"
+plugin_id = "rabbitseason-srv-nfs"
+
+capability {
+  access_mode     = "multi-node-multi-writer"
+  attachment_mode = "file-system"
+}

--- a/nomad/storage/volumes/paperless-export.hcl
+++ b/nomad/storage/volumes/paperless-export.hcl
@@ -1,0 +1,9 @@
+id        = "paperless-export"
+name      = "paperless-export"
+type      = "csi"
+plugin_id = "rabbitseason-mix-nfs"
+
+capability {
+  access_mode     = "multi-node-multi-writer"
+  attachment_mode = "file-system"
+}

--- a/nomad/storage/volumes/paperless-media.hcl
+++ b/nomad/storage/volumes/paperless-media.hcl
@@ -1,0 +1,9 @@
+id        = "paperless-media"
+name      = "paperless-media"
+type      = "csi"
+plugin_id = "rabbitseason-mix-nfs"
+
+capability {
+  access_mode     = "multi-node-multi-writer"
+  attachment_mode = "file-system"
+}


### PR DESCRIPTION
## Summary

- New Nomad job `paperless` running paperless-ngx 2.20.13 with Gotenberg and Apache Tika for Office/email document support
- 4 CSI volumes: search index on `srv` (fast), documents/consume/export on `mix` (bulk)
- Uses shared postgres (no special extensions required)
- Traefik hostname-based routing via `paperless_hostname` in `nomad/jobs/traefik` — hostname never appears in the repo
- Publicly accessible (no `internal-only` middleware) for external access via Newt tunnel
- NFS consume directory uses polling (`PAPERLESS_CONSUMER_POLLING=60`) since inotify doesn't work over NFS

## Services

| Task | Image | Port |
|---|---|---|
| `paperless-webserver` | `paperlessngx/paperless-ngx:2.20.13` | 8000 |
| `paperless-redis` | `redis:7-alpine` | 6380 |
| `paperless-gotenberg` | `gotenberg/gotenberg:8.10.1` | 3001 |
| `paperless-tika` | `apache/tika:3.0.0.0` | 9998 |

## Deploy checklist

- [ ] Create postgres user + database (`bash scripts/pg-connect.sh`)
- [ ] `nomad var put nomad/jobs/paperless db_password=... secret_key=... admin_user=... admin_password=...`
- [ ] Add `paperless_hostname` to `nomad/jobs/traefik`
- [ ] Add public DNS A record for the hostname → hedwig
- [ ] `nomad volume create` for all 4 CSI volumes
- [ ] `nomad job run nomad/infra/traefik/traefik.hcl`
- [ ] `nomad job run nomad/apps/paperless/paperless.hcl`
- [ ] Verify login at `https://<your-hostname>` with configured admin credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)