### PR TITLE
feat: add monitoring for paperless-ngx

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -9,6 +9,7 @@ Prometheus configuration files, mounted into the prometheus container via the
 | `node_exporter_alerting_rules.yml` | Alerts for host-level metrics (disk, memory, load) |
 | `node_exporter_recording_rules.yml` | Pre-computed recording rules for dashboard performance |
 | `blackbox_alerting_rules.yml` | Alerts for failed HTTP/ICMP probes |
+| `paperless_alerting_rules.yml` | Alerts for paperless-ngx (Traefik 5xx error rate) |
 | `prom-alertmanager.yml` | Alert routing and email notification config |
 | `prom-blackbox-exporter.yml` | Probe module definitions (http_2xx, icmp) |
 | `grafana/` | Grafana provisioning config and dashboard JSON files |

--- a/monitoring/paperless_alerting_rules.yml
+++ b/monitoring/paperless_alerting_rules.yml
@@ -1,0 +1,24 @@
+groups:
+- name: paperless
+  rules:
+
+  # >5% of requests to paperless are returning 5xx errors.
+  # Router is defined in the Traefik dynamic file config (dynamic.yml),
+  # so Traefik labels it as paperless@file.
+  - alert: PaperlessHTTP5xxHigh
+    expr: |
+      sum(
+        rate(traefik_router_requests_total{job="traefik",router="paperless@file",code=~"5.."}[5m])
+      )
+      /
+      sum(
+        rate(traefik_router_requests_total{job="traefik",router="paperless@file"}[5m])
+      ) > 0.05
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "High HTTP 5xx error rate on paperless"
+      description: >
+        Paperless is returning {{ $value | humanizePercentage }} 5xx responses
+        over the last 5 minutes (threshold: 5%). Check the paperless-webserver logs.

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -90,6 +90,7 @@ scrape_configs:
           - http://miniflux.service.home.consul:8080/rss
           - z2m.service.home.consul:8081
           - nomad-botherer.service.home.consul:9112
+          - http://paperless.service.home.consul:8000/
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target


### PR DESCRIPTION
## Summary

- Adds `http://paperless.service.home.consul:8000/` to the `blackbox-consul-http` scrape job so the existing `ConsulServiceDown` alert covers paperless
- Adds `paperless_alerting_rules.yml` with a `PaperlessHTTP5xxHigh` alert (>5% 5xx via Traefik's `paperless@file` router, same pattern as Newt services)
- Sidecar services (redis, gotenberg, tika) already have Consul TCP health checks so they're covered by the existing `ConsulServiceCheckCritical` alert

## Test plan

- [x] `bash scripts/check-monitoring-configs.sh` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)