### PR TITLE
fix: replace file-template approach with prometheus_start.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Config files live in `monitoring/` and are mounted into prometheus/alertmanager/
 
 On push to main, the `homelab-webhook` Nomad job (at `nomad/infra/homelab-webhook/`) pulls the repo and POSTs `/-/reload` to prometheus (9090), alertmanager (9093), and blackbox-exporter (9115).
 
-The prometheus container uses a Nomad template to combine `prometheus.yml` (from the gitrepo) with Grafana Cloud `remote_read` credentials (from `nomad/jobs/prometheus`) into `/local/prometheus.yml` at task startup. Credential rotation restarts the task (`change_mode=restart`). Prometheus runs with its standard entrypoint pointing at `/local/prometheus.yml`. Rule files use a glob (`/config/monitoring/*_rules.yml`) so new alert rules are picked up by `/-/reload` (sent by the homelab-webhook on push to main) without a redeploy. Changes to scrape config in `prometheus.yml` require a `nomad job run` redeploy.
+The entrypoint for the prometheus container is `nomad/monitoring/prometheus_start.sh` (from the gitrepo). It concatenates `prometheus.yml` (gitrepo) with a Nomad-rendered `remote_read.yml` (Grafana Cloud credentials from `nomad/jobs/prometheus`) into `/local/prometheus.yml`, then `exec`s prometheus as PID 1. Credential rotation restarts the task (`change_mode=restart`). Rule files use a glob (`/config/monitoring/*_rules.yml`) so new alert rules are picked up by `/-/reload` (sent by the homelab-webhook on push to main) without a redeploy. Changes to scrape config in `prometheus.yml` require a `nomad job run` redeploy.
 
 Prometheus requires `--web.enable-lifecycle` to enable `/-/reload`. Alertmanager and blackbox-exporter enable it by default.
 

--- a/nomad/monitoring/prometheus.hcl
+++ b/nomad/monitoring/prometheus.hcl
@@ -26,15 +26,15 @@ job "prometheus" {
       driver = "docker"
 
       # Grafana Cloud remote_read credentials from nomad/jobs/prometheus.
-      # Combined with the gitrepo prometheus.yml into /local/prometheus.yml at
-      # task startup. change_mode=restart means credential rotation restarts the
-      # task (acceptable — credentials change rarely).
+      # Written to /local/remote_read.yml; prometheus_start.sh concatenates this
+      # with the gitrepo prometheus.yml at container startup.
+      # change_mode=restart: credential rotation restarts the task (acceptable —
+      # credentials change rarely).
       # Rule files use a glob (/config/monitoring/*_rules.yml) so new rule files
       # and alert rule changes are picked up by /-/reload (via the webhook) without
       # a redeploy. Scrape config changes in prometheus.yml require a redeploy.
       template {
         data = <<EOH
-{{ file "/config/monitoring/prometheus.yml" }}
 remote_read:
   - url: "https://{{ with nomadVar "nomad/jobs/prometheus" }}{{ .grafana_metrics_host }}{{ end }}/api/prom/api/v1/read"
     basic_auth:
@@ -42,18 +42,13 @@ remote_read:
       password: "{{ with nomadVar "nomad/jobs/prometheus" }}{{ .grafana_metrics_read_token }}{{ end }}"
     read_recent: true
 EOH
-        destination = "local/prometheus.yml"
+        destination = "local/remote_read.yml"
         change_mode = "restart"
       }
 
       config {
-        image  = "prom/prometheus:v3.11.0"
-        args   = [
-          "--config.file=/local/prometheus.yml",
-          "--storage.tsdb.path=/data/prometheus/prom-tsdb/",
-          "--web.external-url=http://prometheus.service.home.consul:9090/",
-          "--web.enable-lifecycle",
-        ]
+        image      = "prom/prometheus:v3.11.0"
+        entrypoint = ["/bin/sh", "/config/nomad/monitoring/prometheus_start.sh"]
         labels {
           group = "prometheus"
         }

--- a/nomad/monitoring/prometheus_start.sh
+++ b/nomad/monitoring/prometheus_start.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Concatenate the gitrepo prometheus.yml with the Nomad-rendered remote_read
+# credentials, then exec prometheus as PID 1.
+#
+# Paths:
+#   /config/monitoring/prometheus.yml  -- gitrepo CSI volume (scrape config, rules glob)
+#   /local/remote_read.yml             -- Nomad-rendered Grafana Cloud credentials
+#   /local/prometheus.yml              -- combined config read by prometheus
+set -eu
+cat /config/monitoring/prometheus.yml /local/remote_read.yml > /local/prometheus.yml
+exec /bin/prometheus \
+  --config.file=/local/prometheus.yml \
+  --storage.tsdb.path=/data/prometheus/prom-tsdb/ \
+  --web.external-url=http://prometheus.service.home.consul:9090/ \
+  --web.enable-lifecycle


### PR DESCRIPTION
## Summary

`{{ file }}` in Nomad templates is evaluated before the task container starts, so `/config` (the gitrepo volume mount) doesn't exist yet — hence the `lstat /config: no such file or directory` error.

Fix: render only the `remote_read` credentials to `/local/remote_read.yml` via Nomad template (`change_mode=restart`), and use a minimal `prometheus_start.sh` that concatenates at container startup and `exec`s prometheus as PID 1:

```sh
cat /config/monitoring/prometheus.yml /local/remote_read.yml > /local/prometheus.yml
exec /bin/prometheus --config.file=/local/prometheus.yml ...
```

No polling loop, no signal handling, no background process management — just concatenate once and hand off.

## Test plan

- [ ] `nomad job run nomad/monitoring/prometheus.hcl` — verify prometheus starts cleanly
- [ ] Confirm `/-/reload` via webhook picks up rule file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)