### PR TITLE
fix: correct newt metric names and immich router label in dashboard/alerts

### DIFF
--- a/monitoring/grafana/dashboards/newt-services.json
+++ b/monitoring/grafana/dashboards/newt-services.json
@@ -20,7 +20,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "newt_online",
+          "expr": "min(newt_tunnel_sessions) > bool 0",
           "legendFormat": "tunnel",
           "refId": "A"
         }
@@ -103,7 +103,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(increase(newt_proxy_write_drops_total[5m]))",
+          "expr": "sum(increase(newt_proxy_drops_total[5m]))",
           "legendFormat": "drops",
           "refId": "A"
         }
@@ -186,7 +186,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (router) (rate(traefik_router_requests_total{job=\"traefik\",router=~\"(birdnet|kutt|immich)@consulcatalog\"}[$__rate_interval]))",
+          "expr": "sum by (router) (rate(traefik_router_requests_total{job=\"traefik\",router=~\"(birdnet|kutt)@consulcatalog|immich@file\"}[$__rate_interval]))",
           "legendFormat": "{{router}}",
           "refId": "A"
         }
@@ -214,7 +214,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (router, code) (rate(traefik_router_requests_total{job=\"traefik\",router=~\"(birdnet|kutt|immich)@consulcatalog\"}[$__rate_interval]))",
+          "expr": "sum by (router, code) (rate(traefik_router_requests_total{job=\"traefik\",router=~\"(birdnet|kutt)@consulcatalog|immich@file\"}[$__rate_interval]))",
           "legendFormat": "{{router}} — {{code}}",
           "refId": "A"
         }
@@ -259,7 +259,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (router, code) (rate(traefik_router_requests_total{job=\"traefik\",router=~\"(birdnet|kutt|immich)@consulcatalog\",code=~\"4..|5..\"}[$__rate_interval]))",
+          "expr": "sum by (router, code) (rate(traefik_router_requests_total{job=\"traefik\",router=~\"(birdnet|kutt)@consulcatalog|immich@file\",code=~\"4..|5..\"}[$__rate_interval]))",
           "legendFormat": "{{router}} — {{code}}",
           "refId": "A"
         }
@@ -296,13 +296,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "histogram_quantile(0.95, sum by (router, le) (rate(traefik_router_request_duration_seconds_bucket{job=\"traefik\",router=~\"(birdnet|kutt|immich)@consulcatalog\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (router, le) (rate(traefik_router_request_duration_seconds_bucket{job=\"traefik\",router=~\"(birdnet|kutt)@consulcatalog|immich@file\"}[$__rate_interval])))",
           "legendFormat": "{{router}} p95",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "histogram_quantile(0.50, sum by (router, le) (rate(traefik_router_request_duration_seconds_bucket{job=\"traefik\",router=~\"(birdnet|kutt|immich)@consulcatalog\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (router, le) (rate(traefik_router_request_duration_seconds_bucket{job=\"traefik\",router=~\"(birdnet|kutt)@consulcatalog|immich@file\"}[$__rate_interval])))",
           "legendFormat": "{{router}} p50",
           "refId": "B"
         }
@@ -330,13 +330,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(rate(newt_proxy_bytes_received_total[$__rate_interval]))",
+          "expr": "sum(rate(newt_tunnel_bytes_total{direction=\"ingress\"}[$__rate_interval]))",
           "legendFormat": "received",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(rate(newt_proxy_bytes_sent_total[$__rate_interval]))",
+          "expr": "sum(rate(newt_tunnel_bytes_total{direction=\"egress\"}[$__rate_interval]))",
           "legendFormat": "sent",
           "refId": "B"
         }

--- a/monitoring/newt_alerting_rules.yml
+++ b/monitoring/newt_alerting_rules.yml
@@ -10,7 +10,7 @@ groups:
   # All externally-reachable services (birdnet, kutt, immich) are unreachable
   # until this recovers.
   - alert: NewtTunnelOffline
-    expr: newt_online == 0
+    expr: newt_tunnel_sessions == 0
     for: 2m
     labels:
       severity: critical
@@ -25,7 +25,7 @@ groups:
   # More than 10 drops in 5 minutes is worth knowing about.
   - alert: NewtWriteDropsHigh
     expr: |
-      sum(increase(newt_proxy_write_drops_total[5m])) > 10
+      sum(increase(newt_proxy_drops_total[5m])) > 10
     for: 5m
     labels:
       severity: warning
@@ -45,11 +45,11 @@ groups:
   - alert: NewtServiceHTTP5xxHigh
     expr: |
       sum by (router) (
-        rate(traefik_router_requests_total{job="traefik",router=~"(birdnet|kutt|immich)@consulcatalog",code=~"5.."}[5m])
+        rate(traefik_router_requests_total{job="traefik",router=~"(birdnet|kutt)@consulcatalog|immich@file",code=~"5.."}[5m])
       )
       /
       sum by (router) (
-        rate(traefik_router_requests_total{job="traefik",router=~"(birdnet|kutt|immich)@consulcatalog"}[5m])
+        rate(traefik_router_requests_total{job="traefik",router=~"(birdnet|kutt)@consulcatalog|immich@file"}[5m])
       ) > 0.05
     for: 5m
     labels:


### PR DESCRIPTION
## Summary

Several metric names in the Newt dashboard and alert rules were wrong — they didn't match what `fosrl/newt` actually exposes at its Prometheus endpoint:

| Was | Should be |
|---|---|
| `newt_online` | `newt_tunnel_sessions` |
| `newt_proxy_write_drops_total` | `newt_proxy_drops_total` |
| `newt_proxy_bytes_received_total` | `newt_tunnel_bytes_total{direction="ingress"}` |
| `newt_proxy_bytes_sent_total` | `newt_tunnel_bytes_total{direction="egress"}` |

Also fixes the Traefik router label filter in both the dashboard and the `NewtServiceHTTP5xxHigh` alert: immich is routed via Traefik's dynamic file config (not Consul catalog tags), so its router label is `immich@file` not `immich@consulcatalog`. birdnet and kutt correctly use `@consulcatalog`.

The `Tunnel Status` stat panel uses `min(newt_tunnel_sessions) > bool 0` to produce a clean 0/1 for the existing Offline/Online value mappings, since `newt_tunnel_sessions` is a session count rather than a boolean.

## Test plan

- [ ] After merge + webhook reload, verify Tunnel Status, Write Drops, and Tunnel bytes panels show data
- [ ] Verify Traefik panels now show immich traffic alongside birdnet/kutt

🤖 Generated with [Claude Code](https://claude.com/claude-code)