### PR TITLE
fix: use @nomad provider suffix for birdnet/kutt router metrics

### DIFF
--- a/monitoring/grafana/dashboards/newt-services.json
+++ b/monitoring/grafana/dashboards/newt-services.json
@@ -186,7 +186,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (router) (rate(traefik_router_requests_total{job=\"traefik\",router=~\"(birdnet|kutt)@consulcatalog|immich@file\"}[$__rate_interval]))",
+          "expr": "sum by (router) (rate(traefik_router_requests_total{job=\"traefik\",router=~\"(birdnet|kutt)@nomad|immich@file\"}[$__rate_interval]))",
           "legendFormat": "{{router}}",
           "refId": "A"
         }
@@ -214,7 +214,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (router, code) (rate(traefik_router_requests_total{job=\"traefik\",router=~\"(birdnet|kutt)@consulcatalog|immich@file\"}[$__rate_interval]))",
+          "expr": "sum by (router, code) (rate(traefik_router_requests_total{job=\"traefik\",router=~\"(birdnet|kutt)@nomad|immich@file\"}[$__rate_interval]))",
           "legendFormat": "{{router}} — {{code}}",
           "refId": "A"
         }
@@ -259,7 +259,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum by (router, code) (rate(traefik_router_requests_total{job=\"traefik\",router=~\"(birdnet|kutt)@consulcatalog|immich@file\",code=~\"4..|5..\"}[$__rate_interval]))",
+          "expr": "sum by (router, code) (rate(traefik_router_requests_total{job=\"traefik\",router=~\"(birdnet|kutt)@nomad|immich@file\",code=~\"4..|5..\"}[$__rate_interval]))",
           "legendFormat": "{{router}} — {{code}}",
           "refId": "A"
         }
@@ -296,13 +296,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "histogram_quantile(0.95, sum by (router, le) (rate(traefik_router_request_duration_seconds_bucket{job=\"traefik\",router=~\"(birdnet|kutt)@consulcatalog|immich@file\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (router, le) (rate(traefik_router_request_duration_seconds_bucket{job=\"traefik\",router=~\"(birdnet|kutt)@nomad|immich@file\"}[$__rate_interval])))",
           "legendFormat": "{{router}} p95",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "histogram_quantile(0.50, sum by (router, le) (rate(traefik_router_request_duration_seconds_bucket{job=\"traefik\",router=~\"(birdnet|kutt)@consulcatalog|immich@file\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (router, le) (rate(traefik_router_request_duration_seconds_bucket{job=\"traefik\",router=~\"(birdnet|kutt)@nomad|immich@file\"}[$__rate_interval])))",
           "legendFormat": "{{router}} p50",
           "refId": "B"
         }

--- a/monitoring/newt_alerting_rules.yml
+++ b/monitoring/newt_alerting_rules.yml
@@ -45,11 +45,11 @@ groups:
   - alert: NewtServiceHTTP5xxHigh
     expr: |
       sum by (router) (
-        rate(traefik_router_requests_total{job="traefik",router=~"(birdnet|kutt)@consulcatalog|immich@file",code=~"5.."}[5m])
+        rate(traefik_router_requests_total{job="traefik",router=~"(birdnet|kutt)@nomad|immich@file",code=~"5.."}[5m])
       )
       /
       sum by (router) (
-        rate(traefik_router_requests_total{job="traefik",router=~"(birdnet|kutt)@consulcatalog|immich@file"}[5m])
+        rate(traefik_router_requests_total{job="traefik",router=~"(birdnet|kutt)@nomad|immich@file"}[5m])
       ) > 0.05
     for: 5m
     labels:


### PR DESCRIPTION
## Summary

Traefik is configured with the native Nomad provider (`providers.nomad`), not the Consul catalog provider. Router labels in Traefik metrics are therefore `birdnet@nomad` and `kutt@nomad`, not `birdnet@consulcatalog`.

Fixes the blank Requests/sec, HTTP status codes, error rate, and P95 latency panels in the Newt Services dashboard, and corrects the `NewtServiceHTTP5xxHigh` alert rule which would never have fired.

## Test plan

- [ ] After merge + webhook reload, verify the Traefik panels in the Newt Services dashboard show data for birdnet, kutt, and immich

🤖 Generated with [Claude Code](https://claude.com/claude-code)