### PR TITLE
fix: add paperless.service.home.consul to PAPERLESS_ALLOWED_HOSTS

### DIFF
--- a/nomad/apps/paperless/paperless.hcl
+++ b/nomad/apps/paperless/paperless.hcl
@@ -184,7 +184,7 @@ PAPERLESS_SECRET_KEY={{ .secret_key }}
 PAPERLESS_ADMIN_USER={{ .admin_user }}
 PAPERLESS_ADMIN_PASSWORD={{ .admin_password }}
 PAPERLESS_URL=https://{{ .hostname }}
-PAPERLESS_ALLOWED_HOSTS={{ .hostname }},localhost
+PAPERLESS_ALLOWED_HOSTS={{ .hostname }},localhost,paperless.service.home.consul
 PAPERLESS_CSRF_TRUSTED_ORIGINS=https://{{ .hostname }}
 {{- end }}
 PAPERLESS_DBENGINE=postgresql


### PR DESCRIPTION
## Summary

- Blackbox probe hits paperless via `http://paperless.service.home.consul:8000/` with a `Host: paperless.service.home.consul` header
- Django rejects requests where the `Host` header isn't in `ALLOWED_HOSTS`, returning 400
- This caused false `ConsulServiceDown` alerts even when paperless is healthy
- Fix: add `paperless.service.home.consul` to `PAPERLESS_ALLOWED_HOSTS`

## Test plan

- [ ] Merge and redeploy: `nomad job run nomad/apps/paperless/paperless.hcl`
- [ ] Confirm `ConsulServiceDown` alert for paperless clears in Alertmanager

🤖 Generated with [Claude Code](https://claude.com/claude-code)