### PR TITLE
feat: install Docker on rabbitseason via new docker inventory group

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -86,6 +86,19 @@ nomadconsul:
                   - "192.168.100.251"
                   - "192.168.100.253"
 
+# Hosts that should have Docker installed but are not Nomad nodes.
+# Nomad nodes get Docker via the hashicorp role dependency.
+docker:
+        hosts:
+                rabbitseason:
+                        ansible_user: doc
+        vars:
+                download_arch: amd64
+                docker_dns_servers:
+                  - "192.168.100.250"
+                  - "192.168.100.251"
+                  - "192.168.100.253"
+
 # All physical hosts that should run node_exporter.
 node_exporter:
         children:

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -35,6 +35,13 @@
   roles:
     - role: ups
 
+- name: docker hosts (non-nomad)
+  hosts: docker
+  become: true
+  become_user: root
+  roles:
+    - role: docker
+
 - name: all physical hosts
   hosts: node_exporter
   any_errors_fatal: false


### PR DESCRIPTION
## Summary

- rabbitseason (NFS server) needs Docker but is not a Nomad node
- Nomad nodes already get Docker as a `hashicorp` role dependency
- Adds a standalone `docker` inventory group + play for hosts that need Docker without Nomad
- rabbitseason gets the same `daemon.json` config (DNS servers) as the Nomad hosts

## Test plan

- [ ] Merge and run: `ansible-playbook -i ansible/inventory.yml ansible/site.yml --limit rabbitseason`
- [ ] Confirm `docker-ce` installed and daemon running on rabbitseason

🤖 Generated with [Claude Code](https://claude.com/claude-code)