### PR TITLE
ci: Phase 1 validation workflows + single version source of truth

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,25 @@
+name: Lint Ansible
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "ansible/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "ansible/**"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ansible-lint
+        run: pip install ansible-lint
+
+      # Lint local roles only — site.yml references an external Galaxy role
+      # (ansible-nfs-server) that is not committed to the repo.
+      - name: Run ansible-lint
+        run: ansible-lint ansible/roles/

--- a/.github/workflows/nomad-validate.yml
+++ b/.github/workflows/nomad-validate.yml
@@ -1,0 +1,35 @@
+name: Validate Nomad jobs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "nomad/**"
+      - "versions.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "nomad/**"
+      - "versions.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read Nomad version
+        id: versions
+        run: |
+          ver=$(grep '^nomad_version:' versions.yml | awk '{print $2}' | tr -d '"')
+          echo "nomad_version=${ver}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate all Nomad job files
+        run: |
+          find nomad -name "*.hcl" | sort | while read -r f; do
+            echo "==> $f"
+            docker run --rm \
+              -v "$GITHUB_WORKSPACE:/workspace:ro" \
+              "hashicorp/nomad:${{ steps.versions.outputs.nomad_version }}" \
+              job validate "/workspace/$f"
+          done

--- a/.github/workflows/nomad-validate.yml
+++ b/.github/workflows/nomad-validate.yml
@@ -26,7 +26,12 @@ jobs:
 
       - name: Validate all Nomad job files
         run: |
-          find nomad -name "*.hcl" | sort | while read -r f; do
+          # Exclude acl/ (policy files) and storage/volumes/ (volume registration
+          # files) — neither are job specs and nomad job validate rejects them.
+          find nomad -name "*.hcl" \
+            -not -path "nomad/acl/*" \
+            -not -path "nomad/storage/volumes/*" \
+            | sort | while read -r f; do
             echo "==> $f"
             docker run --rm \
               -v "$GITHUB_WORKSPACE:/workspace:ro" \

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -1,0 +1,28 @@
+name: Validate Terraform
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "terraform/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "terraform/**"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+
+      - name: terraform init
+        run: terraform -chdir=terraform/grafana-sm init -backend=false
+
+      - name: terraform validate
+        run: terraform -chdir=terraform/grafana-sm validate
+
+      - name: terraform fmt check
+        run: terraform fmt -check -recursive terraform/

--- a/ansible/roles/hashicorp/tasks/main.yml
+++ b/ansible/roles/hashicorp/tasks/main.yml
@@ -1,5 +1,9 @@
 # --- Hashicorp apt repo setup ---
 
+- name: Load version variables from repo root
+  ansible.builtin.include_vars:
+    file: "{{ playbook_dir }}/../versions.yml"
+
 - name: Gather package facts
   ansible.builtin.package_facts:
     manager: apt

--- a/ansible/roles/hashicorp/vars/main.yml
+++ b/ansible/roles/hashicorp/vars/main.yml
@@ -1,2 +1,2 @@
-consul_version: 1.22.1
-nomad_version: 1.11.0
+# Versions are defined in versions.yml at the repo root.
+# The hashicorp tasks load them via include_vars at runtime.

--- a/versions.yml
+++ b/versions.yml
@@ -1,0 +1,5 @@
+# Pinned versions for HashiCorp tools installed by Ansible.
+# This is the single source of truth — CI workflows and the Ansible
+# hashicorp role both read from here.
+nomad_version: "1.11.0"
+consul_version: "1.22.1"


### PR DESCRIPTION
## Summary

- Introduces `versions.yml` at the repo root as the single source of truth for pinned HashiCorp tool versions (`nomad_version`, `consul_version`). Previously these only existed inside the Ansible role.
- Updates the `hashicorp` Ansible role to load `versions.yml` via `include_vars` (using `playbook_dir` to resolve the path), replacing the now-empty `vars/main.yml` version pins.
- Adds three new path-scoped CI workflows:

| Workflow | Trigger path | What it does |
|---|---|---|
| `nomad-validate.yml` | `nomad/**`, `versions.yml` | `nomad job validate` on every `*.hcl` under `nomad/`, using the pinned Nomad version from `versions.yml` via the `hashicorp/nomad` Docker image |
| `terraform-validate.yml` | `terraform/**` | `terraform init -backend=false`, `validate`, and `fmt -check` on `terraform/grafana-sm/` |
| `ansible-lint.yml` | `ansible/**` | `ansible-lint` on `ansible/roles/` (local roles only; `site.yml` references an external Galaxy role not in the repo) |

## Test plan

- [ ] Open a PR that touches a Nomad HCL file — confirm `nomad-validate.yml` runs and passes
- [ ] Introduce a deliberate syntax error in a `.hcl` file — confirm the workflow fails
- [ ] Open a PR touching `terraform/` — confirm `terraform-validate.yml` runs
- [ ] Open a PR touching `ansible/roles/` — confirm `ansible-lint.yml` runs
- [ ] Bump `nomad_version` in `versions.yml` — confirm `nomad-validate.yml` triggers and uses the new version
- [ ] Run the Ansible playbook against a test host to confirm `include_vars` resolves correctly

https://claude.ai/code/session_0194diM74NBkGSK73newkzFD

---
_Generated by [Claude Code](https://claude.ai/code/session_0194diM74NBkGSK73newkzFD)_