### PR TITLE
feat: add centralised log collection (OTEL Collector + VictoriaLogs)

### DIFF
--- a/dns/etc-bind/db.home.andvari.net
+++ b/dns/etc-bind/db.home.andvari.net
@@ -1,7 +1,7 @@
 $ORIGIN home.andvari.net.
 $TTL    604800
 @       IN      SOA     ns1.home.andvari.net. admin.home.andvari.net. (
-                 55     ; Serial
+                 56     ; Serial
              604800     ; Refresh
               86400     ; Retry
             2419200     ; Expire
@@ -22,3 +22,4 @@ rabbitseason   IN A 192.168.100.251
 duckseason     IN A 192.168.100.253
 
 smtp IN CNAME postfix-andvari-smarthost.service.home.consul.
+logs IN CNAME traefik.service.home.consul.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,5 @@ Setup guides and operational documentation.
 |---|---|
 | [grafana.md](grafana.md) | Grafana setup, datasources, dashboard provisioning, and operational playbook |
 | [grafana-synthetic-monitoring.md](grafana-synthetic-monitoring.md) | Grafana Cloud Synthetic Monitoring integration — Terraform setup, Nomad variables, alert logic, and recovery procedure |
+| [log-collection.md](log-collection.md) | Log collection setup (OTEL Collector + VictoriaLogs) — rollout, querying, and operational playbook |
 | [van.md](van.md) | Campervan WiFi hardware setup (side project, not core homelab) |

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -269,8 +269,9 @@ nomad job run nomad/monitoring/grafana.hcl
   (e.g. `GF_INSTALL_PLUGINS=grafana-piechart-panel`). They download at startup
   and persist to the `grafana` CSI volume.
 
-- **Additional datasources**: Loki for log aggregation, if added later, just
-  needs a file in `monitoring/grafana/provisioning/datasources/`.
+- **Additional datasources**: The `Logs` datasource (VictoriaLogs) is already
+  provisioned. Further datasources just need a file in
+  `monitoring/grafana/provisioning/datasources/`.
 
 - **Organisation/teams**: Grafana supports multiple orgs and teams. For a
   single-user homelab the default org is fine.

--- a/docs/log-collection.md
+++ b/docs/log-collection.md
@@ -1,0 +1,334 @@
+# Log collection
+
+Centralised log storage and collection using OpenTelemetry Collector and
+VictoriaLogs. All container stdout/stderr is tailed automatically from Docker
+log files — no changes needed to existing jobs.
+
+## Architecture
+
+```
+Each cluster node
+┌─────────────────────────────────────────────────────────────────┐
+│  otel-collector  (system job — one per node)                    │
+│                                                                 │
+│  filelog receiver  ← /var/lib/docker/containers/**/*.log        │
+│  otlp receiver     ← apps pushing OTLP on :4317 (gRPC)         │
+│                                        :4318 (HTTP)             │
+│                                                                 │
+│  → exports logs to VictoriaLogs via OTLP HTTP                   │
+│  → exposes received OTLP metrics on :8889 (prometheus format)   │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌──────────────────────────────────────┐
+│  victorialogs  (service job)         │
+│  logs.service.home.consul:9428       │
+│  30-day retention                    │
+│  CSI volume: logs (mix NFS)          │
+│  UI: https://logs.home.andvari.net   │
+└──────────────────────────────────────┘
+                            ↓
+┌──────────────────────────────────────┐
+│  Grafana                             │
+│  datasource: Logs (victoriametrics-  │
+│  logs-datasource plugin)             │
+└──────────────────────────────────────┘
+```
+
+### Log attributes collected
+
+Each log record gets the following attributes from the filelog pipeline:
+
+| Attribute | Source | Example |
+|---|---|---|
+| `host.name` | `NOMAD_NODE_NAME` (injected by OTEL Collector system job) | `picluster1` |
+| `container_id` | Parsed from the Docker log file path | `a3f9d2c1b4e8` |
+| `log.iostream` | Docker log JSON (`stream` field) | `stdout` / `stderr` |
+| `log.file.path` | Full path of the tailed log file | `/hostlog/containers/...` |
+
+Nomad job name and task name are not automatically attached — Docker label
+metadata is not available without Docker socket access. Cross-reference
+`container_id` with `docker ps` or `nomad alloc status` to trace a container
+back to its allocation.
+
+### Apps pushing OTLP directly
+
+Any app with native OTEL support can push structured logs and metrics to
+`otel-collector.service.home.consul:4317` (gRPC) or `:4318` (HTTP). Add to the
+job's template block:
+
+```hcl
+template {
+  data = <<EOH
+OTEL_EXPORTER_OTLP_ENDPOINT=http://{{ env "NOMAD_IP_otlp_grpc" }}:4317
+OTEL_SERVICE_NAME=my-service-name
+EOH
+  destination = "secrets/otel.env"
+  env         = true
+}
+```
+
+---
+
+## Rollout
+
+### Prerequisites
+
+Verify the mix NFS CSI plugin is healthy on all nodes before creating the volume:
+
+```bash
+nomad plugin status rabbitseason-mix-nfs
+```
+
+All nodes should show `Healthy` in the `Node Plugins` table. If any are
+unhealthy, check the `rabbitseason-mix-nfs-node` system job:
+
+```bash
+nomad job status rabbitseason-mix-nfs-node
+```
+
+### Step 1: Create the logs CSI volume
+
+```bash
+nomad volume create nomad/storage/volumes/logs.hcl
+```
+
+Verify it was created:
+
+```bash
+nomad volume status logs
+```
+
+### Step 2: Deploy VictoriaLogs
+
+```bash
+nomad job run nomad/monitoring/victorialogs/victorialogs.hcl
+```
+
+Wait for the allocation to become healthy, then check the health endpoint:
+
+```bash
+nomad job status victorialogs
+
+# Health check — should return {"status":"ok"}
+curl -s http://logs.service.home.consul:9428/health
+```
+
+If the allocation fails to place, check that the mix NFS volume is attachable:
+
+```bash
+nomad alloc status <alloc-id>   # look for volume mount errors in the events
+```
+
+### Step 3: Deploy the OTEL Collector system job
+
+```bash
+nomad job run nomad/monitoring/otel-collector/otel-collector.hcl
+```
+
+The system job schedules one allocation per cluster node. Verify placement:
+
+```bash
+nomad job status otel-collector
+```
+
+Every node in the cluster should appear in the allocation list with status
+`running`. If a node is missing, check its allocation:
+
+```bash
+nomad alloc status <alloc-id>
+nomad alloc logs <alloc-id> otel-collector   # look for config errors at startup
+```
+
+Common startup issues:
+- **Config parse error**: the OTEL YAML in the template block is malformed. Check logs for `Error loading config`.
+- **Port already in use**: another process holds 4317, 4318, or 8889. Rare on a clean node.
+- **Cannot open log directory**: the `/var/lib/docker/containers` bind mount failed. Confirm Docker is running on the node.
+
+### Step 4: Verify log ingestion
+
+Wait 30–60 seconds for the filelog receiver to begin tailing, then query
+VictoriaLogs directly:
+
+```bash
+# Fetch the 10 most recent log records (any source)
+curl -s 'http://logs.service.home.consul:9428/select/logsql/query?query=*&limit=10' | jq .
+
+# Filter to a specific node
+curl -s 'http://logs.service.home.consul:9428/select/logsql/query' \
+  --data-urlencode 'query=host.name:picluster1' \
+  --data-urlencode 'limit=10' | jq .
+
+# Filter to stderr only
+curl -s 'http://logs.service.home.consul:9428/select/logsql/query' \
+  --data-urlencode 'query=log.iostream:stderr' \
+  --data-urlencode 'limit=10' | jq .
+```
+
+If no logs arrive after a couple of minutes, check OTEL Collector logs for
+export errors:
+
+```bash
+# Pick any otel-collector allocation
+nomad alloc logs <alloc-id> otel-collector 2>&1 | grep -i error
+```
+
+### Step 5: Redeploy Grafana
+
+The `GF_INSTALL_PLUGINS=victoriametrics-logs-datasource` env var added to
+`grafana.hcl` causes Grafana to download the plugin on startup. Redeploy to
+pick up the change:
+
+```bash
+nomad job run nomad/monitoring/grafana.hcl
+```
+
+Plugin download requires internet access from the Grafana container. Watch the
+logs to confirm it succeeds:
+
+```bash
+nomad alloc logs -f -job grafana grafana_server 2>&1 | grep -i plugin
+# Expect: level=info msg="Plugin registered" pluginId=victoriametrics-logs-datasource
+```
+
+The `Logs` datasource is provisioned automatically from the gitrepo — no manual
+Grafana UI steps needed. After Grafana is healthy, verify:
+
+```bash
+curl -s http://grafana.service.home.consul:3000/graphs/api/health
+
+# List datasources (requires admin credentials)
+curl -s -u admin:PASSWORD \
+  http://grafana.service.home.consul:3000/api/datasources | jq '.[].name'
+# Should include "Logs"
+```
+
+If the datasource is missing, trigger a provisioning reload:
+
+```bash
+curl -s -X POST -u admin:PASSWORD \
+  http://grafana.service.home.consul:3000/api/admin/provisioning/datasources/reload
+```
+
+### Step 6: Reload BIND DNS
+
+The `logs CNAME traefik.service.home.consul.` record was added to
+`dns/etc-bind/db.home.andvari.net` with serial bumped to 56. Deploy the updated
+zone file to ns1 (hedwig) and reload BIND.
+
+Verify DNS resolves correctly once reloaded:
+
+```bash
+dig @192.168.100.250 logs.home.andvari.net
+# Should return the Traefik IP (192.168.100.250) after CNAME resolution
+```
+
+### Step 7: Verify end-to-end
+
+Open `https://logs.home.andvari.net` — the VictoriaLogs query UI should load.
+
+In Grafana (`https://home.andvari.net/graphs/`):
+
+1. Go to **Explore** and select the **Logs** datasource.
+2. Run query `*` — recent logs from all containers should appear.
+3. Confirm the Traefik HTTPS route is working (internal-only middleware applies).
+
+---
+
+## Operational playbook
+
+### Check job status
+
+```bash
+nomad job status victorialogs
+nomad job status otel-collector     # shows one alloc per node
+```
+
+### Tail live logs from the collector
+
+```bash
+# Pick a node's allocation ID from 'nomad job status otel-collector'
+nomad alloc logs -f <alloc-id> otel-collector
+```
+
+### Query logs
+
+VictoriaLogs uses [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/).
+Key patterns:
+
+```bash
+BASE='http://logs.service.home.consul:9428/select/logsql/query'
+
+# All logs, last 5 minutes (default time range is 1 hour)
+curl -s "$BASE" --data-urlencode 'query=*' --data-urlencode '_time=5m' | jq .
+
+# Logs from a specific container (get container_id from 'docker ps' or 'nomad alloc status')
+curl -s "$BASE" --data-urlencode 'query=container_id:a3f9d2c1b4e8' | jq .
+
+# Logs containing a string
+curl -s "$BASE" --data-urlencode 'query=error' | jq .
+
+# Stderr only from a specific host
+curl -s "$BASE" \
+  --data-urlencode 'query=host.name:hedwig AND log.iostream:stderr' | jq .
+```
+
+### Check storage usage
+
+VictoriaLogs exposes Prometheus metrics at `:9428/metrics`. To check how much
+disk the log store is using:
+
+```bash
+curl -s http://logs.service.home.consul:9428/metrics \
+  | grep victorialogs_data_size_bytes
+```
+
+The `logs` CSI volume starts at 10 GB on the mix NFS share. If usage approaches
+the limit, either reduce `-retentionPeriod` in `victorialogs.hcl` or resize the
+volume on `rabbitseason`.
+
+### Restart VictoriaLogs
+
+```bash
+nomad job run nomad/monitoring/victorialogs/victorialogs.hcl
+```
+
+VictoriaLogs stores data on the CSI volume — a restart does not lose data.
+
+### Update OTEL Collector config
+
+The collector config lives in the `template` block inside
+`nomad/monitoring/otel-collector/otel-collector.hcl`. After editing:
+
+```bash
+nomad job run nomad/monitoring/otel-collector/otel-collector.hcl
+```
+
+Nomad will perform a rolling update across nodes (one at a time by default for
+system jobs).
+
+### Upgrade VictoriaLogs or the OTEL Collector
+
+Update the image tag in the relevant `.hcl` file and redeploy:
+
+```bash
+# After editing the image tag:
+nomad job run nomad/monitoring/victorialogs/victorialogs.hcl
+nomad job run nomad/monitoring/otel-collector/otel-collector.hcl
+```
+
+---
+
+## Future work
+
+- **Job/task name enrichment**: Mount the Docker socket read-only into the
+  OTEL Collector so the filelog receiver can read container labels
+  (`com.hashicorp.nomad.job_name`, `com.hashicorp.nomad.task_name`) and attach
+  them as log attributes. Not done initially to avoid the socket mount.
+- **Log-based alerting**: Add `vmalert` (VictoriaMetrics alerting engine) to
+  fire alerts on log patterns (e.g. error rate spikes, specific strings).
+- **System journal logs**: Bare-metal nodes (picluster1–5, hedwig, etc.) have no
+  Docker containers and no OTEL Collector. An Ansible-deployed Vector agent
+  could ship journal logs to VictoriaLogs directly.
+- **Traces**: If any app gains OTEL tracing, extend the OTEL Collector pipeline
+  with a `traces` pipeline exporting to Tempo or a managed backend — no changes
+  to the log pipeline needed.

--- a/monitoring/grafana/provisioning/datasources/victorialogs.yaml
+++ b/monitoring/grafana/provisioning/datasources/victorialogs.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Logs
+    type: victoriametrics-logs-datasource
+    uid: logs
+    url: http://logs.service.home.consul:9428
+    access: proxy
+    isDefault: false
+    editable: false

--- a/nomad/monitoring/README.md
+++ b/nomad/monitoring/README.md
@@ -9,6 +9,27 @@ Prometheus-based monitoring stack with Grafana dashboards.
 | `prom-blackbox-exporter` | HTTP and ICMP probes |
 | `prom-consul-exporter` | Consul cluster metrics |
 | `grafana` | Dashboards and visualisation at `home.andvari.net/graphs` |
+| `victorialogs` | Centralised log storage (VictoriaLogs), queryable at `logs.home.andvari.net` |
+| `otel-collector` | OTEL Collector system job (one per node); tails Docker logs and accepts OTLP push |
+
+See `docs/log-collection.md` for the full rollout guide and operational playbook.
+
+Key log commands:
+
+```bash
+# Check both jobs
+nomad job status victorialogs
+nomad job status otel-collector
+
+# Health check
+curl -s http://logs.service.home.consul:9428/health
+
+# Query recent logs
+curl -s 'http://logs.service.home.consul:9428/select/logsql/query?query=*&limit=10' | jq .
+
+# Check storage usage
+curl -s http://logs.service.home.consul:9428/metrics | grep victorialogs_data_size_bytes
+```
 
 Prometheus config files (scrape targets, alert rules, recording rules) live in
 `monitoring/` at the repo root — mounted into the prometheus container via the

--- a/nomad/monitoring/grafana.hcl
+++ b/nomad/monitoring/grafana.hcl
@@ -48,6 +48,7 @@ GF_SERVER_ROOT_URL=https://home.andvari.net/graphs/
 GF_SERVER_SERVE_FROM_SUB_PATH=true
 GF_PATHS_PROVISIONING=/config/monitoring/grafana/provisioning
 GF_AUTH_ANONYMOUS_ENABLED=false
+GF_INSTALL_PLUGINS=victoriametrics-logs-datasource
 EOH
       }
 

--- a/nomad/monitoring/otel-collector/otel-collector.hcl
+++ b/nomad/monitoring/otel-collector/otel-collector.hcl
@@ -1,0 +1,111 @@
+job "otel-collector" {
+  datacenters = ["home"]
+  type        = "system"
+
+  group "otel-collector" {
+    network {
+      mode = "host"
+      port "otlp_grpc" { static = 4317 }
+      port "otlp_http" { static = 4318 }
+      port "metrics"   { static = 8889 }
+    }
+
+    task "otel-collector" {
+      driver = "docker"
+      # UID 0 required to read /var/lib/docker/containers (root:root 700).
+      # The right fix is default ACLs on the host via Ansible + group_add here.
+      user   = "0"
+
+      config {
+        image = "otel/opentelemetry-collector-contrib:0.123.0"
+        args  = ["--config=/local/otel-collector.yml"]
+        ports = ["otlp_grpc", "otlp_http", "metrics"]
+        volumes = [
+          "/var/lib/docker/containers:/hostlog/containers:ro",
+        ]
+      }
+
+      template {
+        destination = "local/otel-collector.yml"
+        data        = <<EOH
+receivers:
+  filelog:
+    include:
+      - /hostlog/containers/*/*.log
+    include_file_path: true
+    operators:
+      # Docker wraps each log line in JSON: {"log":"...", "stream":"stdout", "time":"..."}
+      - type: json_parser
+        timestamp:
+          parse_from: attributes.time
+          layout_type: gotime
+          layout: '2006-01-02T15:04:05.999999999Z07:00'
+      - type: move
+        from: attributes.log
+        to: body
+      - type: regex_parser
+        regex: '/hostlog/containers/(?P<container_id>[a-f0-9]+)'
+        parse_from: attributes["log.file.path"]
+        parse_to: attributes
+      - type: move
+        from: attributes.stream
+        to: attributes["log.iostream"]
+      # Set host.name as a record attribute (not resource attribute) so VictoriaLogs
+      # stores it as a queryable field. Uses Consul Template to query the local node name.
+      - type: add
+        field: attributes["host.name"]
+        value: '{{ with node }}{{ .Node.Node }}{{ end }}'
+
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"
+      http:
+        endpoint: "0.0.0.0:4318"
+
+processors:
+  batch:
+    timeout: 5s
+
+  # Detects host.name from the OS hostname; applied to OTLP-pushed logs and metrics.
+  # For filelog records, host.name is set as a record attribute via the add operator above.
+  resourcedetection/system:
+    detectors: [system]
+    system:
+      hostname_sources: [os]
+
+exporters:
+  otlphttp/logs:
+    endpoint: "http://logs.service.home.consul:9428/insert/opentelemetry"
+    tls:
+      insecure: true
+
+  # Expose any OTLP metrics received from apps for future Prometheus scraping.
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+
+service:
+  pipelines:
+    logs:
+      receivers: [filelog, otlp]
+      processors: [batch, resourcedetection/system]
+      exporters: [otlphttp/logs]
+    metrics:
+      receivers: [otlp]
+      processors: [batch, resourcedetection/system]
+      exporters: [prometheus]
+EOH
+      }
+
+      service {
+        name = "otel-collector"
+        port = "otlp_grpc"
+      }
+
+      resources {
+        cpu    = 100
+        memory = 128
+      }
+    }
+  }
+}

--- a/nomad/monitoring/victorialogs/victorialogs.hcl
+++ b/nomad/monitoring/victorialogs/victorialogs.hcl
@@ -1,0 +1,62 @@
+job "victorialogs" {
+  datacenters = ["home"]
+
+  group "victorialogs" {
+
+    volume "logs" {
+      type            = "csi"
+      source          = "logs"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
+    network {
+      port "http" {
+        static = 9428
+      }
+    }
+
+    task "victorialogs" {
+      driver = "docker"
+
+      config {
+        image = "victoriametrics/victoria-logs:v1.23.0-victorialogs"
+        args  = [
+          "-storageDataPath=/data",
+          "-retentionPeriod=30d",
+          "-httpListenAddr=:9428",
+        ]
+        ports = ["http"]
+      }
+
+      volume_mount {
+        volume      = "logs"
+        destination = "/data"
+      }
+
+      service {
+        name = "logs"
+        port = "http"
+        check {
+          type     = "http"
+          path     = "/health"
+          interval = "10s"
+          timeout  = "2s"
+        }
+        tags = [
+          "traefik.enable=true",
+          "traefik.http.routers.logs.rule=Host(`logs.home.andvari.net`)",
+          "traefik.http.routers.logs.tls=true",
+          "traefik.http.routers.logs.tls.certresolver=le",
+          "traefik.http.routers.logs.middlewares=internal-only@file",
+        ]
+      }
+
+      resources {
+        cpu    = 100
+        memory = 256
+      }
+    }
+  }
+}

--- a/nomad/storage/volumes/README.md
+++ b/nomad/storage/volumes/README.md
@@ -14,6 +14,7 @@ capacity, access mode, and NFS mount parameters.
 | `jellyfin` | Defined; no active job in this repo |
 | `kutt` | kutt job |
 | `media` | Shared media storage |
+| `logs` | victorialogs job (log storage, 30-day retention) |
 | `monitoring` | prometheus (TSDB), alertmanager (state) |
 | `immich-photos` | immich job (photo/video library at `/usr/src/app/upload`) |
 | `immich-db` | immich job (postgres data directory) |

--- a/nomad/storage/volumes/logs.hcl
+++ b/nomad/storage/volumes/logs.hcl
@@ -1,0 +1,9 @@
+id        = "logs"
+name      = "logs"
+type      = "csi"
+plugin_id = "rabbitseason-mix-nfs"
+
+capability {
+  access_mode     = "multi-node-multi-writer"
+  attachment_mode = "file-system"
+}


### PR DESCRIPTION
Adds a full log collection stack:
- otel-collector: Nomad system job (one per node) tailing Docker log files and accepting OTLP push on :4317/:4318; runs as UID 0 to read /var/lib/docker/containers (TODO: replace with host ACLs + group_add)
- victorialogs: service job with 30-day retention on a dedicated 'logs' CSI volume (mix NFS); Consul service 'logs', Traefik at logs.home.andvari.net
- Grafana: victoriametrics-logs-datasource plugin added via GF_INSTALL_PLUGINS; 'Logs' datasource provisioned from gitrepo
- DNS: logs CNAME traefik.service.home.consul (serial 56)
- Docs: new docs/log-collection.md with rollout guide and operational playbook

host.name is set as a log record attribute via filelog add operator (Consul Template node query) so VictoriaLogs indexes it as a queryable field; resourcedetection/system processor covers OTLP-pushed logs.