### PR TITLE
chore: upgrade monitoring stack (Grafana 13, VictoriaLogs 1.50, OTEL 0.152)

### DIFF
--- a/nomad/monitoring/grafana.hcl
+++ b/nomad/monitoring/grafana.hcl
@@ -48,12 +48,12 @@ GF_SERVER_ROOT_URL=https://home.andvari.net/graphs/
 GF_SERVER_SERVE_FROM_SUB_PATH=true
 GF_PATHS_PROVISIONING=/config/monitoring/grafana/provisioning
 GF_AUTH_ANONYMOUS_ENABLED=false
-GF_INSTALL_PLUGINS=victoriametrics-logs-datasource
+GF_PLUGINS_PREINSTALL_SYNC=victoriametrics-logs-datasource
 EOH
       }
 
       config {
-        image = "grafana/grafana:11.4.0"
+        image = "grafana/grafana:13.0.1"
         ports = ["grafana"]
         dns_search_domains = ["home.andvari.net"]
       }
@@ -81,7 +81,7 @@ EOH
 
       resources {
         cpu    = 200
-        memory = 128
+        memory = 512
       }
     }
   }

--- a/nomad/monitoring/otel-collector/otel-collector.hcl
+++ b/nomad/monitoring/otel-collector/otel-collector.hcl
@@ -17,44 +17,55 @@ job "otel-collector" {
       user   = "0"
 
       config {
-        image = "otel/opentelemetry-collector-contrib:0.123.0"
+        image = "otel/opentelemetry-collector-contrib:0.152.0"
         args  = ["--config=/local/otel-collector.yml"]
         ports = ["otlp_grpc", "otlp_http", "metrics"]
         volumes = [
           "/var/lib/docker/containers:/hostlog/containers:ro",
+          "/var/run/docker.sock:/var/run/docker.sock:ro",
         ]
       }
 
       template {
         destination = "local/otel-collector.yml"
         data        = <<EOH
+extensions:
+  # Watches the Docker daemon for container start/stop events. Used by
+  # receiver_creator to dynamically create a filelog instance per container,
+  # with that container's labels (Nomad job/task/alloc) injected as resource
+  # attributes at discovery time.
+  docker_observer:
+    endpoint: unix:///var/run/docker.sock
+
 receivers:
-  filelog:
-    include:
-      - /hostlog/containers/*/*.log
-    include_file_path: true
-    operators:
-      # Docker wraps each log line in JSON: {"log":"...", "stream":"stdout", "time":"..."}
-      - type: json_parser
-        timestamp:
-          parse_from: attributes.time
-          layout_type: gotime
-          layout: '2006-01-02T15:04:05.999999999Z07:00'
-      - type: move
-        from: attributes.log
-        to: body
-      - type: regex_parser
-        regex: '/hostlog/containers/(?P<container_id>[a-f0-9]+)'
-        parse_from: attributes["log.file.path"]
-        parse_to: attributes
-      - type: move
-        from: attributes.stream
-        to: attributes["log.iostream"]
-      # Set host.name as a record attribute (not resource attribute) so VictoriaLogs
-      # stores it as a queryable field. Uses Consul Template to query the local node name.
-      - type: add
-        field: attributes["host.name"]
-        value: '{{ with node }}{{ .Node.Node }}{{ end }}'
+  receiver_creator:
+    watch_observers: [docker_observer]
+    receivers:
+      filelog:
+        rule: type == "container"
+        config:
+          include:
+            - /hostlog/containers/`container_id`/`container_id`-json.log
+          include_file_path: true
+          operators:
+            # Docker wraps each log line in JSON: {"log":"...", "stream":"stdout", "time":"..."}
+            - type: json_parser
+              timestamp:
+                parse_from: attributes.time
+                layout_type: gotime
+                layout: '2006-01-02T15:04:05.999999999Z07:00'
+            - type: move
+              from: attributes.log
+              to: body
+            - type: move
+              from: attributes.stream
+              to: attributes["log.iostream"]
+          resource:
+            nomad.job:      '`labels["com.hashicorp.nomad.job_name"]`'
+            nomad.task:     '`labels["com.hashicorp.nomad.task_name"]`'
+            nomad.group:    '`labels["com.hashicorp.nomad.task_group_name"]`'
+            nomad.alloc_id: '`labels["com.hashicorp.nomad.alloc_id"]`'
+            container.id:   '`container_id`'
 
   otlp:
     protocols:
@@ -67,12 +78,22 @@ processors:
   batch:
     timeout: 5s
 
-  # Detects host.name from the OS hostname; applied to OTLP-pushed logs and metrics.
-  # For filelog records, host.name is set as a record attribute via the add operator above.
   resourcedetection/system:
     detectors: [system]
     system:
       hostname_sources: [os]
+
+  # Promote Nomad labels and host.name from resource attributes to log record
+  # attributes so VictoriaLogs indexes them as queryable fields.
+  transform/record_attrs:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["nomad.job"],      resource.attributes["nomad.job"])
+          - set(attributes["nomad.task"],     resource.attributes["nomad.task"])
+          - set(attributes["nomad.group"],    resource.attributes["nomad.group"])
+          - set(attributes["nomad.alloc_id"], resource.attributes["nomad.alloc_id"])
+          - set(attributes["host.name"],      resource.attributes["host.name"])
 
 exporters:
   otlphttp/logs:
@@ -85,10 +106,11 @@ exporters:
     endpoint: "0.0.0.0:8889"
 
 service:
+  extensions: [docker_observer]
   pipelines:
     logs:
-      receivers: [filelog, otlp]
-      processors: [batch, resourcedetection/system]
+      receivers: [receiver_creator, otlp]
+      processors: [batch, resourcedetection/system, transform/record_attrs]
       exporters: [otlphttp/logs]
     metrics:
       receivers: [otlp]

--- a/nomad/monitoring/victorialogs/victorialogs.hcl
+++ b/nomad/monitoring/victorialogs/victorialogs.hcl
@@ -21,7 +21,7 @@ job "victorialogs" {
       driver = "docker"
 
       config {
-        image = "victoriametrics/victoria-logs:v1.23.0-victorialogs"
+        image = "victoriametrics/victoria-logs:v1.50.0"
         args  = [
           "-storageDataPath=/data",
           "-retentionPeriod=30d",


### PR DESCRIPTION
## Summary

- **Grafana** 11.4.0 → 13.0.1; bumped memory to 512 MB (was OOM-killing); switched deprecated `GF_INSTALL_PLUGINS` to `GF_PLUGINS_PREINSTALL_SYNC`
- **VictoriaLogs** v1.23.0 → v1.50.0; fixes `contains_common_case()` LogsQL errors in the Grafana datasource plugin
- **OTEL Collector** 0.123.0 → 0.152.0; switches from plain `filelog` to `receiver_creator` + `docker_observer` so each container's Nomad labels (`nomad.job`, `nomad.task`, `nomad.group`, `nomad.alloc_id`) are injected as queryable fields in VictoriaLogs; adds Docker socket mount

## Test plan

- [ ] Grafana loads at `https://home.andvari.net/graphs/` without OOM
- [ ] `Logs` datasource present in Grafana; error log view no longer fails with `contains_common_case` error
- [ ] `nomad.job` field present on log records in VictoriaLogs: `curl -s 'http://logs.service.home.consul:9428/select/logsql/query?query=*&limit=5&fields=nomad.job,nomad.task,host.name,_msg' | jq .`
- [ ] OTEL Collector running on all nodes: `nomad job status otel-collector`

🤖 Generated with [Claude Code](https://claude.com/claude-code)