### PR TITLE
fix: extract nomad.task and fix host.name in otel-collector

### DIFF
--- a/docs/log-collection.md
+++ b/docs/log-collection.md
@@ -40,15 +40,19 @@ Each log record gets the following attributes from the filelog pipeline:
 
 | Attribute | Source | Example |
 |---|---|---|
-| `host.name` | `NOMAD_NODE_NAME` (injected by OTEL Collector system job) | `picluster1` |
-| `container_id` | Parsed from the Docker log file path | `a3f9d2c1b4e8` |
+| `host.name` | Nomad node name, injected at template render time | `picluster1` |
+| `nomad.alloc_id` | Docker label `com.hashicorp.nomad.alloc_id` | `65b5cd12-b346-...` |
+| `nomad.task` | Extracted from container name (`<task>-<alloc-uuid>`) | `grafana` |
+| `container.name` | Set by docker_observer (`<task>-<alloc-uuid>`) | `grafana-65b5cd12-...` |
+| `container.id` | Full container SHA | `a3f9d2c1b4e8...` |
 | `log.iostream` | Docker log JSON (`stream` field) | `stdout` / `stderr` |
 | `log.file.path` | Full path of the tailed log file | `/hostlog/containers/...` |
 
-Nomad job name and task name are not automatically attached — Docker label
-metadata is not available without Docker socket access. Cross-reference
-`container_id` with `docker ps` or `nomad alloc status` to trace a container
-back to its allocation.
+Nomad job name and group name are not attached — Docker only sets `alloc_id`
+as a label; job/group names are only in container environment variables, which
+the docker_observer does not expose to the receiver_creator expression language.
+Cross-reference `nomad.alloc_id` with `nomad alloc status <alloc-id>` to map a
+log record back to its Nomad job.
 
 ### Apps pushing OTLP directly
 

--- a/nomad/monitoring/otel-collector/otel-collector.hcl
+++ b/nomad/monitoring/otel-collector/otel-collector.hcl
@@ -31,9 +31,7 @@ job "otel-collector" {
         data        = <<EOH
 extensions:
   # Watches the Docker daemon for container start/stop events. Used by
-  # receiver_creator to dynamically create a filelog instance per container,
-  # with that container's labels (Nomad job/task/alloc) injected as resource
-  # attributes at discovery time.
+  # receiver_creator to dynamically create a filelog instance per container.
   docker_observer:
     endpoint: unix:///var/run/docker.sock
 
@@ -61,9 +59,6 @@ receivers:
               from: attributes.stream
               to: attributes["log.iostream"]
           resource:
-            nomad.job:      '`labels["com.hashicorp.nomad.job_name"]`'
-            nomad.task:     '`labels["com.hashicorp.nomad.task_name"]`'
-            nomad.group:    '`labels["com.hashicorp.nomad.task_group_name"]`'
             nomad.alloc_id: '`labels["com.hashicorp.nomad.alloc_id"]`'
             container.id:   '`container_id`'
 
@@ -83,17 +78,20 @@ processors:
     system:
       hostname_sources: [os]
 
-  # Promote Nomad labels and host.name from resource attributes to log record
-  # attributes so VictoriaLogs indexes them as queryable fields.
+  # Promote key fields to log record attributes so VictoriaLogs indexes them.
+  # host.name is injected from the Nomad node name at template render time
+  # because resourcedetection/system returns the container's internal hostname
+  # (its short container ID), not the physical host.
+  # nomad.task is extracted from container.name, which docker_observer sets to
+  # "<task_name>-<alloc-uuid>". The alloc UUID is always 36 chars; stripping 37
+  # chars (UUID + preceding hyphen) leaves the task name.
   transform/record_attrs:
     log_statements:
       - context: log
         statements:
-          - set(attributes["nomad.job"],      resource.attributes["nomad.job"])
-          - set(attributes["nomad.task"],     resource.attributes["nomad.task"])
-          - set(attributes["nomad.group"],    resource.attributes["nomad.group"])
+          - set(attributes["host.name"],      "{{ with node }}{{ .Node.Node }}{{ end }}")
           - set(attributes["nomad.alloc_id"], resource.attributes["nomad.alloc_id"])
-          - set(attributes["host.name"],      resource.attributes["host.name"])
+          - set(attributes["nomad.task"],     Substring(resource.attributes["container.name"], 0, Len(resource.attributes["container.name"]) - 37)) where resource.attributes["nomad.alloc_id"] != nil
 
 exporters:
   otlphttp/logs:
@@ -110,7 +108,7 @@ service:
   pipelines:
     logs:
       receivers: [receiver_creator, otlp]
-      processors: [batch, resourcedetection/system, transform/record_attrs]
+      processors: [batch, transform/record_attrs]
       exporters: [otlphttp/logs]
     metrics:
       receivers: [otlp]


### PR DESCRIPTION
## Summary

- Replaces the broken `env_vars["NOMAD_JOB_NAME"]` approach in the `receiver_creator` resource block — `docker_observer` does not actually expose container environment variables in the expression language regardless of `env_vars:` config
- **`nomad.task`**: now extracted from `container.name` via OTTL `Substring`, stripping the trailing 37-char alloc UUID suffix (Nomad container name format is always `<task>-<alloc-uuid>`)
- **`host.name`**: now injected via Consul Template `{{ with node }}...{{ end }}` at render time; the previous `resourcedetection/system` approach was returning the Docker container's internal hostname (its short container ID, e.g. `c885046b8791`) rather than the physical host name

`nomad.job` and `nomad.group` remain unavailable — Docker only sets `alloc_id` as a label, and container env vars are not accessible via the OTEL collector's docker_observer expression language.

## Test plan

- [x] Deployed version 12, all 4 nodes healthy
- [x] VictoriaLogs records show `host.name: "duckseason"` / `host.name: "rabbitseason"` (real physical hostnames)
- [x] VictoriaLogs records show `nomad.task: "otel-collector"`, `nomad.task: "prom-blackbox-exporter_server"` etc.
- [x] No errors in otel-collector stderr (only a deprecation warning for `otlphttp` alias, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)