### PR TITLE
feat: add esphome job

### DIFF
--- a/nomad/apps/README.md
+++ b/nomad/apps/README.md
@@ -11,6 +11,7 @@ User-facing applications.
 | `kutt` | URL shortener at go.home.andvari.net | Backed by postgres and CSI NFS volume; secrets in `nomad/jobs/kutt` |
 | `immich` | Self-hosted photo/video management | Dedicated postgres+vectorchord, Redis, ML; photos on mix, DB on srv |
 | `paperless` | Document management (paperless-ngx) | Shared postgres, Redis + Gotenberg + Tika sidecars; media/consume/export on mix, index on srv |
+| `esphome` | ESPHome dashboard for ESP8266/ESP32 firmware | Config on srv CSI volume; OTA-only (no USB); at `esphome.service.home.consul:6052` |
 
 ## Hardware-pinned jobs
 

--- a/nomad/apps/esphome/esphome.hcl
+++ b/nomad/apps/esphome/esphome.hcl
@@ -29,8 +29,7 @@ job "esphome" {
         image   = "ghcr.io/esphome/esphome:2026.5.0"
         ports   = ["http"]
         # -v raises log level to DEBUG; use -vv for full VERBOSE output
-        command = "esphome"
-        args    = ["-v", "dashboard", "/config"]
+        args = ["-v", "dashboard", "/config"]
       }
 
       volume_mount {

--- a/nomad/apps/esphome/esphome.hcl
+++ b/nomad/apps/esphome/esphome.hcl
@@ -26,8 +26,11 @@ job "esphome" {
       }
 
       config {
-        image = "ghcr.io/esphome/esphome:2025.5.0"
-        ports = ["http"]
+        image   = "ghcr.io/esphome/esphome:2026.5.0"
+        ports   = ["http"]
+        # -v raises log level to DEBUG; use -vv for full VERBOSE output
+        command = "esphome"
+        args    = ["-v", "dashboard", "/config"]
       }
 
       volume_mount {

--- a/nomad/apps/esphome/esphome.hcl
+++ b/nomad/apps/esphome/esphome.hcl
@@ -1,0 +1,50 @@
+job "esphome" {
+  datacenters = ["home"]
+
+  group "esphome" {
+    volume "esphome" {
+      type            = "csi"
+      source          = "esphome"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
+    task "esphome" {
+      driver = "docker"
+
+      service {
+        name = "esphome"
+        port = "http"
+        check {
+          name     = "HTTP"
+          type     = "http"
+          path     = "/"
+          interval = "30s"
+          timeout  = "5s"
+        }
+      }
+
+      config {
+        image = "ghcr.io/esphome/esphome:2025.5.0"
+        ports = ["http"]
+      }
+
+      volume_mount {
+        volume      = "esphome"
+        destination = "/config"
+      }
+
+      resources {
+        cpu        = 500
+        memory     = 512
+        memory_max = 1024
+      }
+    }
+
+    network {
+      mode = "host"
+      port "http" { static = 6052 }
+    }
+  }
+}

--- a/nomad/storage/volumes/esphome.hcl
+++ b/nomad/storage/volumes/esphome.hcl
@@ -1,0 +1,9 @@
+id        = "esphome"
+name      = "esphome"
+type      = "csi"
+plugin_id = "rabbitseason-srv-nfs"
+
+capability {
+  access_mode     = "multi-node-multi-writer"
+  attachment_mode = "file-system"
+}


### PR DESCRIPTION
## Summary

- Adds ESPHome dashboard job (`nomad/apps/esphome/esphome.hcl`) on port 6052
- Adds `esphome` CSI volume on srv NFS (`nomad/storage/volumes/esphome.hcl`)
- OTA-only (no USB passthrough), internal access only
- Debug logging enabled (`-v`) to surface install/compile progress

## Rollout

```bash
nomad volume create nomad/storage/volumes/esphome.hcl
nomad job run nomad/apps/esphome/esphome.hcl
```

Dashboard at `http://esphome.service.home.consul:6052`

🤖 Generated with [Claude Code](https://claude.com/claude-code)