### PR TITLE
chore: bump nomad-botherer to 0.1.2

### DIFF
--- a/nomad/infra/nomad-botherer/nomad-botherer.hcl
+++ b/nomad/infra/nomad-botherer/nomad-botherer.hcl
@@ -16,7 +16,7 @@ job "nomad-botherer" {
       driver = "docker"
 
       config {
-        image = "ghcr.io/gerrowadat/nomad-botherer:0.1.1"
+        image = "ghcr.io/gerrowadat/nomad-botherer:0.1.2"
         ports = ["nomad-botherer"]
       }
 


### PR DESCRIPTION
## Summary
- Bumps `ghcr.io/gerrowadat/nomad-botherer` from `0.1.1` to `0.1.2`

## Test plan
- [ ] Deploy with `nomad job run nomad/infra/nomad-botherer/nomad-botherer.hcl` and verify the new image pulls and the service registers healthy in Consul

🤖 Generated with [Claude Code](https://claude.com/claude-code)