### PR TITLE
feat: opt all apps jobs into nomad-botherer drift monitoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ scripts/          Utility scripts (validation, reload helpers)
 - amd64-only images get a constraint: `attribute = "${attr.cpu.arch}" operator = "=" value = "amd64"`.
 - All `nomad/apps/` jobs must opt in to nomad-botherer drift monitoring with a top-level meta block:
   ```hcl
-  meta {
+  meta = {
     "gitops.managed" = "true"
   }
   ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,12 @@ scripts/          Utility scripts (validation, reload helpers)
 - Secrets go in Nomad variables at `nomad/jobs/<jobname>`, injected via `template` blocks into `secrets/env` with `env = true`. Variables must be created manually before deploying.
 - The `user` field (to run as a specific user) is a **task-level** field, not inside `config {}`.
 - amd64-only images get a constraint: `attribute = "${attr.cpu.arch}" operator = "=" value = "amd64"`.
+- All `nomad/apps/` jobs must opt in to nomad-botherer drift monitoring with a top-level meta block:
+  ```hcl
+  meta {
+    "gitops.managed" = "true"
+  }
+  ```
 
 ## Traefik routing
 

--- a/nomad/apps/birdnet/birdnet.hcl
+++ b/nomad/apps/birdnet/birdnet.hcl
@@ -1,7 +1,7 @@
 job "birdnet" {
   datacenters = ["home"]
 
-  meta {
+  meta = {
     "gitops.managed" = "true"
   }
 

--- a/nomad/apps/birdnet/birdnet.hcl
+++ b/nomad/apps/birdnet/birdnet.hcl
@@ -1,5 +1,10 @@
 job "birdnet" {
   datacenters = ["home"]
+
+  meta {
+    "gitops.managed" = "true"
+  }
+
   group "birdnet_servers" {
 
     volume "birdnet" {

--- a/nomad/apps/cringesweeper/cringesweeper.hcl
+++ b/nomad/apps/cringesweeper/cringesweeper.hcl
@@ -1,5 +1,10 @@
 job "cringesweeper" {
   datacenters = ["home"]
+
+  meta {
+    "gitops.managed" = "true"
+  }
+
   group "cringesweeper_servers" {
     count = 1
     task "cringesweeper" {

--- a/nomad/apps/cringesweeper/cringesweeper.hcl
+++ b/nomad/apps/cringesweeper/cringesweeper.hcl
@@ -1,7 +1,7 @@
 job "cringesweeper" {
   datacenters = ["home"]
 
-  meta {
+  meta = {
     "gitops.managed" = "true"
   }
 

--- a/nomad/apps/esphome/esphome.hcl
+++ b/nomad/apps/esphome/esphome.hcl
@@ -1,7 +1,7 @@
 job "esphome" {
   datacenters = ["home"]
 
-  meta {
+  meta = {
     "gitops.managed" = "true"
   }
 

--- a/nomad/apps/esphome/esphome.hcl
+++ b/nomad/apps/esphome/esphome.hcl
@@ -1,6 +1,10 @@
 job "esphome" {
   datacenters = ["home"]
 
+  meta {
+    "gitops.managed" = "true"
+  }
+
   group "esphome" {
     volume "esphome" {
       type            = "csi"

--- a/nomad/apps/immich/immich.hcl
+++ b/nomad/apps/immich/immich.hcl
@@ -1,6 +1,10 @@
 job "immich" {
   datacenters = ["home"]
 
+  meta {
+    "gitops.managed" = "true"
+  }
+
   group "immich" {
 
     # Photos library — stored on mix (large media NFS share)

--- a/nomad/apps/immich/immich.hcl
+++ b/nomad/apps/immich/immich.hcl
@@ -1,7 +1,7 @@
 job "immich" {
   datacenters = ["home"]
 
-  meta {
+  meta = {
     "gitops.managed" = "true"
   }
 

--- a/nomad/apps/kutt/kutt.hcl
+++ b/nomad/apps/kutt/kutt.hcl
@@ -1,7 +1,7 @@
 job "kutt" {
   datacenters = ["home"]
 
-  meta {
+  meta = {
     "gitops.managed" = "true"
   }
 

--- a/nomad/apps/kutt/kutt.hcl
+++ b/nomad/apps/kutt/kutt.hcl
@@ -1,6 +1,10 @@
 job "kutt" {
   datacenters = ["home"]
 
+  meta {
+    "gitops.managed" = "true"
+  }
+
   group "kutt_servers" {
 
     volume "kutt" {

--- a/nomad/apps/miniflux/miniflux.hcl
+++ b/nomad/apps/miniflux/miniflux.hcl
@@ -1,7 +1,7 @@
 job "miniflux" {
   datacenters = ["home"]
 
-  meta {
+  meta = {
     "gitops.managed" = "true"
   }
 

--- a/nomad/apps/miniflux/miniflux.hcl
+++ b/nomad/apps/miniflux/miniflux.hcl
@@ -1,5 +1,10 @@
 job "miniflux" {
   datacenters = ["home"]
+
+  meta {
+    "gitops.managed" = "true"
+  }
+
   group "miniflux_servers" {
     task "miniflux_server" {
       service {

--- a/nomad/apps/octoprint/octoprint.hcl
+++ b/nomad/apps/octoprint/octoprint.hcl
@@ -1,5 +1,10 @@
 job "octoprint" {
   datacenters = ["home"]
+
+  meta {
+    "gitops.managed" = "true"
+  }
+
   group "octoprint_servers" {
 
     volume "octoprint" {

--- a/nomad/apps/octoprint/octoprint.hcl
+++ b/nomad/apps/octoprint/octoprint.hcl
@@ -1,7 +1,7 @@
 job "octoprint" {
   datacenters = ["home"]
 
-  meta {
+  meta = {
     "gitops.managed" = "true"
   }
 

--- a/nomad/apps/paperless/paperless.hcl
+++ b/nomad/apps/paperless/paperless.hcl
@@ -1,7 +1,7 @@
 job "paperless" {
   datacenters = ["home"]
 
-  meta {
+  meta = {
     "gitops.managed" = "true"
   }
 

--- a/nomad/apps/paperless/paperless.hcl
+++ b/nomad/apps/paperless/paperless.hcl
@@ -1,6 +1,10 @@
 job "paperless" {
   datacenters = ["home"]
 
+  meta {
+    "gitops.managed" = "true"
+  }
+
   group "paperless" {
 
     # Search index and application state — fast storage on srv.


### PR DESCRIPTION
## Summary
- Adds `meta { "gitops.managed" = "true" }` to all 8 jobs under `nomad/apps/` (birdnet, cringesweeper, esphome, immich, kutt, miniflux, octoprint, paperless)
- Documents the convention in `CLAUDE.md` under Nomad job conventions

## Test plan
- [ ] After merging, nomad-botherer should start reporting these jobs in its drift checks — verify via `curl http://nomad-botherer.service.home.consul:9112/healthz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)