### PR TITLE
feat: upgrade nomad-botherer to 0.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,8 @@ scripts/          Utility scripts (validation, reload helpers)
 - amd64-only images get a constraint: `attribute = "${attr.cpu.arch}" operator = "=" value = "amd64"`.
 - All `nomad/apps/` jobs must opt in to nomad-botherer drift monitoring with a top-level meta block:
   ```hcl
-  meta = {
-    "gitops.managed" = "true"
+  meta {
+    gitops_managed = "true"
   }
   ```
 

--- a/nomad/apps/birdnet/birdnet.hcl
+++ b/nomad/apps/birdnet/birdnet.hcl
@@ -1,8 +1,8 @@
 job "birdnet" {
   datacenters = ["home"]
 
-  meta = {
-    "gitops.managed" = "true"
+  meta {
+    gitops_managed = "true"
   }
 
   group "birdnet_servers" {

--- a/nomad/apps/cringesweeper/cringesweeper.hcl
+++ b/nomad/apps/cringesweeper/cringesweeper.hcl
@@ -1,8 +1,8 @@
 job "cringesweeper" {
   datacenters = ["home"]
 
-  meta = {
-    "gitops.managed" = "true"
+  meta {
+    gitops_managed = "true"
   }
 
   group "cringesweeper_servers" {

--- a/nomad/apps/esphome/esphome.hcl
+++ b/nomad/apps/esphome/esphome.hcl
@@ -1,8 +1,8 @@
 job "esphome" {
   datacenters = ["home"]
 
-  meta = {
-    "gitops.managed" = "true"
+  meta {
+    gitops_managed = "true"
   }
 
   group "esphome" {

--- a/nomad/apps/immich/immich.hcl
+++ b/nomad/apps/immich/immich.hcl
@@ -1,8 +1,8 @@
 job "immich" {
   datacenters = ["home"]
 
-  meta = {
-    "gitops.managed" = "true"
+  meta {
+    gitops_managed = "true"
   }
 
   group "immich" {

--- a/nomad/apps/kutt/kutt.hcl
+++ b/nomad/apps/kutt/kutt.hcl
@@ -1,8 +1,8 @@
 job "kutt" {
   datacenters = ["home"]
 
-  meta = {
-    "gitops.managed" = "true"
+  meta {
+    gitops_managed = "true"
   }
 
   group "kutt_servers" {

--- a/nomad/apps/miniflux/miniflux.hcl
+++ b/nomad/apps/miniflux/miniflux.hcl
@@ -1,8 +1,8 @@
 job "miniflux" {
   datacenters = ["home"]
 
-  meta = {
-    "gitops.managed" = "true"
+  meta {
+    gitops_managed = "true"
   }
 
   group "miniflux_servers" {

--- a/nomad/apps/octoprint/octoprint.hcl
+++ b/nomad/apps/octoprint/octoprint.hcl
@@ -1,8 +1,8 @@
 job "octoprint" {
   datacenters = ["home"]
 
-  meta = {
-    "gitops.managed" = "true"
+  meta {
+    gitops_managed = "true"
   }
 
   group "octoprint_servers" {

--- a/nomad/apps/paperless/paperless.hcl
+++ b/nomad/apps/paperless/paperless.hcl
@@ -1,8 +1,8 @@
 job "paperless" {
   datacenters = ["home"]
 
-  meta = {
-    "gitops.managed" = "true"
+  meta {
+    gitops_managed = "true"
   }
 
   group "paperless" {

--- a/nomad/infra/nomad-botherer/nomad-botherer.hcl
+++ b/nomad/infra/nomad-botherer/nomad-botherer.hcl
@@ -16,7 +16,7 @@ job "nomad-botherer" {
       driver = "docker"
 
       config {
-        image = "ghcr.io/gerrowadat/nomad-botherer:0.1.2"
+        image = "ghcr.io/gerrowadat/nomad-botherer:0.2.0"
         ports = ["nomad-botherer"]
       }
 


### PR DESCRIPTION
## Summary
- Bumps `ghcr.io/gerrowadat/nomad-botherer` from `0.1.2` to `0.2.0`
- **Breaking change**: 0.2.0 changes the meta key separator from `.` to `_`. Updates all 8 `nomad/apps/` jobs from `meta = { "gitops.managed" = "true" }` to `meta { gitops_managed = "true" }` (also switches back to block syntax since the key no longer contains a dot)
- Updates the convention in `CLAUDE.md`

## Test plan
- [ ] Deploy nomad-botherer: `nomad job run nomad/infra/nomad-botherer/nomad-botherer.hcl`
- [ ] Redeploy affected apps jobs so the new meta key takes effect
- [ ] Verify drift monitoring picks up apps via `curl http://nomad-botherer.service.home.consul:9112/healthz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)