### PR TITLE
feat: add bother.sh CLI wrapper for nomad-botherer JSON API

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,6 +15,7 @@ Utility scripts for operating the homelab cluster.
 | `nomad-var-set.sh` | Update a single key in a Nomad variable without touching the other keys. Usage: `bash scripts/nomad-var-set.sh <path> <key> <value>`. |
 | `dump-nomad-vars.sh` | Dump all Nomad variables to an AES-256-CBC encrypted bash restore script. Use for disaster-recovery backups; restore by decrypting and piping to bash. See below. |
 | `volume-shell.sh` | Start an interactive shell with a Nomad CSI volume mounted at `/<volume-name>`. Useful for inspecting or modifying volume contents directly. |
+| `bother.sh` | CLI wrapper for the nomad-botherer JSON API. Reads the API key from `nomad/jobs/nomad-botherer` and exposes all API endpoints as subcommands (`diffs`, `refresh`, `status`, etc.). Requires `NOMAD_TOKEN`. |
 
 ## Nomad variable backup and restore
 

--- a/scripts/bother.sh
+++ b/scripts/bother.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# bother.sh — CLI wrapper for the nomad-botherer JSON API.
+#
+# Reads the API key from the Nomad variable at nomad/jobs/nomad-botherer and
+# calls the nomad-botherer HTTP API. Authenticated endpoints require
+# NOMAD_TOKEN to be set so the key can be fetched.
+#
+# Usage: bother.sh <command>
+#
+# Requires: nomad, curl, jq
+# Optional: NOMAD_ADDR, NOMAD_TOKEN, NOMAD_BOTHERER_ADDR
+
+set -euo pipefail
+
+BOTHERER_ADDR="${NOMAD_BOTHERER_ADDR:-http://nomad-botherer.service.home.consul:9112}"
+VAR_PATH="nomad/jobs/nomad-botherer"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+usage() {
+    cat >&2 <<EOF
+Usage: $(basename "$0") <command>
+
+Authenticated commands (require NOMAD_TOKEN):
+  diffs           Current job drift report
+  selected-jobs   Jobs being watched and why they matched
+  status          Git watcher status (last commit, last fetch time)
+  version         Build version and commit hash
+  refresh         Trigger an immediate git pull + diff check
+
+Unauthenticated commands:
+  healthz         Health check + drift summary
+  metrics         Prometheus metrics
+  spec            OpenAPI 3.0 specification (JSON)
+
+Environment:
+  NOMAD_TOKEN           Nomad ACL token (required for authenticated commands)
+  NOMAD_ADDR            Nomad API address (default: http://127.0.0.1:4646)
+  NOMAD_BOTHERER_ADDR   Override the botherer address
+                        (default: http://nomad-botherer.service.home.consul:9112)
+EOF
+    exit 1
+}
+
+get_api_key() {
+    [[ -n "${NOMAD_TOKEN:-}" ]] || die "NOMAD_TOKEN is not set"
+    local key
+    key=$(nomad var get -out=json "$VAR_PATH" 2>/dev/null \
+        | jq -r '.Items.github_webhook_secret' 2>/dev/null || true)
+    [[ -n "$key" && "$key" != "null" ]] \
+        || die "could not read github_webhook_secret from ${VAR_PATH} — check NOMAD_TOKEN"
+    printf '%s' "$key"
+}
+
+bother_get() {
+    curl -sf \
+        -H "Authorization: Bearer $1" \
+        "${BOTHERER_ADDR}$2" \
+      | jq .
+}
+
+bother_post() {
+    curl -sf -X POST \
+        -H "Authorization: Bearer $1" \
+        "${BOTHERER_ADDR}$2" \
+      | jq .
+}
+
+bother_anon() {
+    curl -sf "${BOTHERER_ADDR}$1"
+}
+
+[[ $# -ge 1 ]] || usage
+CMD="$1"; shift
+
+case "$CMD" in
+    diffs)          bother_get "$(get_api_key)" /api/v1/diffs ;;
+    selected-jobs)  bother_get "$(get_api_key)" /api/v1/selected-jobs ;;
+    status)         bother_get "$(get_api_key)" /api/v1/status ;;
+    version)        bother_get "$(get_api_key)" /api/v1/version ;;
+    refresh)        bother_post "$(get_api_key)" /api/v1/refresh ;;
+    healthz)        bother_anon /healthz | jq . ;;
+    metrics)        bother_anon /metrics ;;
+    spec)           bother_anon /api/openapi.json | jq . ;;
+    -h|--help|help) usage ;;
+    *)              echo "Unknown command: ${CMD}" >&2; usage ;;
+esac


### PR DESCRIPTION
## Summary

- Adds `scripts/bother.sh`, a bash CLI wrapper for the nomad-botherer JSON API
- Reads the API key automatically from `nomad/jobs/nomad-botherer` Nomad variable
- Exposes all API endpoints as subcommands: `diffs`, `selected-jobs`, `status`, `version`, `refresh`, `healthz`, `metrics`, `spec`
- Updates `scripts/README.md` with a table entry for the new script

## Test plan

- [ ] `NOMAD_TOKEN=<token> bash scripts/bother.sh version` returns build info JSON
- [ ] `NOMAD_TOKEN=<token> bash scripts/bother.sh diffs` returns drift report
- [ ] `NOMAD_TOKEN=<token> bash scripts/bother.sh refresh` triggers a git pull
- [ ] `bash scripts/bother.sh healthz` works without a token
- [ ] `bash scripts/bother.sh spec` dumps the OpenAPI spec without a token
- [ ] Missing `NOMAD_TOKEN` produces a clear error for authenticated commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)