### PR TITLE
feat: add Home Assistant and Matter server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ bash scripts/reload_prometheus_blackbox.sh
 |---|---|---|
 | `picluster1`–`picluster4` | arm64 | General cluster nodes |
 | `picluster5` | arm64 | 3D printer (octoprint), Zigbee stick (z2m) |
-| `hedwig` | amd64 | Traefik (ports 80/443), Home Assistant, on UPS |
+| `hedwig` | amd64 | Traefik (ports 80/443), on UPS |
 | `rabbitseason` | amd64 | NFS server (CSI volumes) |
 | `duckseason` | amd64 | On networking UPS; NUT daemon for UPS monitoring |
 

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -92,6 +92,7 @@ scrape_configs:
           - nomad-botherer.service.home.consul:9112
           - http://paperless.service.home.consul:8000/
           - logs.service.home.consul:9428
+          - hass.service.home.consul:8123
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target
@@ -110,6 +111,7 @@ scrape_configs:
           - mosquitto.service.home.consul:1883
           - mysql.service.home.consul:3306
           - postgres.service.home.consul:5432
+          - matter-server.service.home.consul:5580
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target

--- a/nomad/apps/README.md
+++ b/nomad/apps/README.md
@@ -12,6 +12,8 @@ User-facing applications.
 | `immich` | Self-hosted photo/video management | Dedicated postgres+vectorchord, Redis, ML; photos on mix, DB on srv |
 | `paperless` | Document management (paperless-ngx) | Shared postgres, Redis + Gotenberg + Tika sidecars; media/consume/export on mix, index on srv |
 | `esphome` | ESPHome dashboard for ESP8266/ESP32 firmware | Config on srv CSI volume; OTA-only (no USB); at `esphome.service.home.consul:6052` |
+| `hass` | Home Assistant home automation hub | Postgres recorder (no SQLite on NFS); at `hass.home.andvari.net` |
+| `matter-server` | python-matter-server WebSocket backend for HA | HA connects to `matter-server.service.home.consul:5580`; device state on NFS volume |
 
 ## Hardware-pinned jobs
 

--- a/nomad/apps/hass/README.md
+++ b/nomad/apps/hass/README.md
@@ -1,0 +1,65 @@
+# hass
+
+Home Assistant — home automation hub.
+
+- URL: hostname set via `hass_hostname` in `nomad/jobs/traefik` (internal network only)
+- Port: 8123 (host network)
+- Config volume: `hass` CSI NFS volume, mounted at `/config`
+- Database: shared Postgres (`homeassistant` DB), used by the recorder integration
+
+## Prerequisites
+
+### 1. Create the Postgres database and user
+
+```bash
+bash scripts/pg-connect.sh
+```
+
+```sql
+CREATE DATABASE homeassistant;
+CREATE USER homeassistant WITH PASSWORD 'yourpassword';
+GRANT ALL PRIVILEGES ON DATABASE homeassistant TO homeassistant;
+-- Must connect to the target DB before granting on its public schema (PG15+)
+\c homeassistant
+GRANT ALL ON SCHEMA public TO homeassistant;
+\q
+```
+
+### 2. Register the CSI volume
+
+```bash
+nomad volume create nomad/storage/volumes/hass.hcl
+```
+
+### 3. Create the Nomad variable for HA secrets
+
+```bash
+nomad var put nomad/jobs/hass db_password=yourpassword hostname=hass.example.com
+```
+
+`hostname` is used by HA for `external_url`/`internal_url` in `configuration.yaml`. It should match the value you set for `hass_hostname` in `nomad/jobs/traefik` (step 4).
+
+### 4. Add the hostname to the Traefik variable
+
+Open the Nomad UI → Variables → `nomad/jobs/traefik` and add key `hass_hostname` with the same hostname. Then redeploy Traefik to pick up the new routing rule.
+
+## Deploy
+
+```bash
+nomad job run nomad/apps/hass/hass.hcl
+```
+
+On first deploy, the `hass-init` prestart task writes a starter `configuration.yaml`
+to the volume. Subsequent deploys are a no-op for that file — edit it directly on the
+NFS volume to customise HA.
+
+## Notes
+
+- **Image version**: Check `ghcr.io/home-assistant/home-assistant` tags and pin to the
+  latest stable (format `YYYY.M.X`) before deploying.
+- **HACS**: Install via the UI after onboarding. The NFS volume has plenty of space for
+  custom components.
+- **SQLite**: Not used — the recorder is configured to write history to Postgres from
+  first boot, so `home-assistant_v2.db` will not be created on the NFS volume.
+- **Zigbee**: Z2M runs on `picluster5` and publishes to `mosquitto`. Add the MQTT
+  integration in the HA UI pointing at `mosquitto.service.home.consul`.

--- a/nomad/apps/hass/hass.hcl
+++ b/nomad/apps/hass/hass.hcl
@@ -1,0 +1,134 @@
+job "hass" {
+  datacenters = ["home"]
+
+  meta {
+    gitops_managed = "true"
+  }
+
+  group "hass" {
+    volume "hass" {
+      type            = "csi"
+      source          = "hass"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
+    # Writes /config/configuration.yaml on first deploy if it doesn't exist.
+    # On subsequent deploys it's a no-op, so it's safe to edit the file directly.
+    task "hass-init" {
+      lifecycle {
+        hook    = "prestart"
+        sidecar = false
+      }
+
+      driver = "docker"
+
+      config {
+        image      = "alpine:3.20"
+        entrypoint = ["/bin/sh", "/local/init.sh"]
+      }
+
+      template {
+        data        = <<SCRIPT
+#!/bin/sh
+set -e
+if [ ! -f /config/configuration.yaml ]; then
+  echo "Writing initial configuration.yaml..."
+  cp /local/configuration.yaml /config/configuration.yaml
+  echo "Done."
+else
+  echo "configuration.yaml already exists, skipping."
+fi
+SCRIPT
+        destination = "local/init.sh"
+        perms       = "0755"
+      }
+
+      template {
+        data = <<EOF
+# Home Assistant configuration
+# Written by Nomad on first deploy only. Safe to edit in-place on the volume.
+
+homeassistant:
+  name: Home
+  unit_system: metric
+  time_zone: Europe/Dublin
+  country: IE
+  external_url: "https://{{ with nomadVar "nomad/jobs/hass" }}{{ .hostname }}{{ end }}"
+  internal_url: "https://{{ with nomadVar "nomad/jobs/hass" }}{{ .hostname }}{{ end }}"
+
+# Required when running behind Traefik in host-network mode.
+# Traefik connects to HA from 127.0.0.1, so that's the trusted proxy address.
+http:
+  use_x_forwarded_for: true
+  trusted_proxies:
+    - 127.0.0.1
+    - 192.168.100.0/24
+
+# Postgres recorder — avoids SQLite on NFS.
+# Requires 'homeassistant' DB and user; see README for setup.
+recorder:
+  db_url: "postgresql://homeassistant:{{ with nomadVar "nomad/jobs/hass" }}{{ .db_password }}{{ end }}@postgres.service.home.consul/homeassistant"
+  purge_keep_days: 30
+
+logger:
+  default: debug
+
+default_config:
+EOF
+        destination = "local/configuration.yaml"
+      }
+
+      volume_mount {
+        volume      = "hass"
+        destination = "/config"
+      }
+
+      resources {
+        cpu    = 50
+        memory = 64
+      }
+    }
+
+    task "hass" {
+      driver = "docker"
+
+      service {
+        name = "hass"
+        port = "http"
+        check {
+          name     = "TCP"
+          type     = "tcp"
+          interval = "30s"
+          timeout  = "10s"
+        }
+      }
+
+      config {
+        image = "ghcr.io/home-assistant/home-assistant:2026.6.1"
+        ports = ["http"]
+      }
+
+      volume_mount {
+        volume      = "hass"
+        destination = "/config"
+      }
+
+      resources {
+        cpu        = 1000
+        memory     = 1024
+        memory_max = 2048
+      }
+
+      env {
+        TZ = "Europe/Dublin"
+      }
+    }
+
+    network {
+      mode = "host"
+      port "http" { static = 8123 }
+    }
+  }
+}

--- a/nomad/apps/matter-server/matter-server.hcl
+++ b/nomad/apps/matter-server/matter-server.hcl
@@ -1,0 +1,55 @@
+job "matter-server" {
+  datacenters = ["home"]
+
+  meta {
+    gitops_managed = "true"
+  }
+
+  group "matter-server" {
+    volume "matter-server" {
+      type            = "csi"
+      source          = "matter-server"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+    }
+
+    task "matter-server" {
+      driver = "docker"
+
+      service {
+        name = "matter-server"
+        port = "ws"
+        check {
+          name     = "TCP"
+          type     = "tcp"
+          interval = "30s"
+          timeout  = "5s"
+        }
+      }
+
+      config {
+        image        = "ghcr.io/home-assistant-libs/python-matter-server:8.1.0"
+        ports        = ["ws"]
+        args         = ["--storage-path", "/data"]
+        security_opt = ["apparmor=unconfined"]
+      }
+
+      volume_mount {
+        volume      = "matter-server"
+        destination = "/data"
+      }
+
+      resources {
+        cpu        = 200
+        memory     = 256
+        memory_max = 512
+      }
+    }
+
+    network {
+      mode = "host"
+      port "ws" { static = 5580 }
+    }
+  }
+}

--- a/nomad/infra/traefik/traefik.hcl
+++ b/nomad/infra/traefik/traefik.hcl
@@ -131,17 +131,22 @@ http:
   middlewares:
     internal-only:
       ipAllowList:
-        # Restricts access to the homelab LAN. Apply to any router that
-        # should not be reachable from the internet.
+        # Restricts access to the homelab LAN. Use for services reachable via
+        # Pangolin -- depth:1 extracts the real client IP from X-Forwarded-For
+        # (without it, ipAllowList would check RemoteAddr = 172.17.0.1 via Newt).
         sourceRange:
           - "192.168.100.0/24"
 {{ with nomadVar "nomad/jobs/traefik" }}{{ with .home_ip }}          - "{{ . }}/32"
 {{ end }}{{ end }}        ipStrategy:
-          # Use the real client IP from X-Forwarded-For (depth=1 = leftmost,
-          # i.e. the original client as seen by the first proxy -- Pangolin).
-          # Without this, ipAllowList checks RemoteAddr (172.17.0.1 via Newt)
-          # rather than the forwarded IP.
           depth: 1
+    internal-only-direct:
+      ipAllowList:
+        # Restricts access to the homelab LAN. Use for services only accessed
+        # directly (not via Pangolin) -- checks RemoteAddr, not X-Forwarded-For.
+        sourceRange:
+          - "192.168.100.0/24"
+{{ with nomadVar "nomad/jobs/traefik" }}{{ with .home_ip }}          - "{{ . }}/32"
+{{ end }}{{ end }}
 
   routers:
     sonarr:
@@ -198,6 +203,12 @@ http:
       tls:
         certResolver: le
       service: paperless
+{{ end }}{{ end }}{{ with nomadVar "nomad/jobs/traefik" }}{{ with .hass_hostname }}    hass:
+      rule: "Host(`{{ . }}`)"
+      tls:
+        certResolver: le
+      middlewares: [internal-only-direct]
+      service: hass
 {{ end }}{{ end }}
   services:
     # Consul DNS resolves these to wherever the service is currently running.
@@ -241,6 +252,10 @@ http:
       loadBalancer:
         servers:
           - url: "http://paperless.service.home.consul:8000"
+{{ end }}{{ end }}{{ with nomadVar "nomad/jobs/traefik" }}{{ with .hass_hostname }}    hass:
+      loadBalancer:
+        servers:
+          - url: "http://hass.service.home.consul:8123"
 {{ end }}{{ end }}
 EOH
         destination = "local/dynamic.yml"

--- a/nomad/storage/volumes/hass.hcl
+++ b/nomad/storage/volumes/hass.hcl
@@ -1,0 +1,9 @@
+id = "hass"
+name = "hass"
+type = "csi"
+plugin_id = "rabbitseason-srv-nfs"
+
+capability {
+  access_mode     = "multi-node-multi-writer"
+  attachment_mode = "file-system"
+}

--- a/nomad/storage/volumes/matter-server.hcl
+++ b/nomad/storage/volumes/matter-server.hcl
@@ -1,0 +1,9 @@
+id = "matter-server"
+name = "matter-server"
+type = "csi"
+plugin_id = "rabbitseason-srv-nfs"
+
+capability {
+  access_mode     = "multi-node-multi-writer"
+  attachment_mode = "file-system"
+}


### PR DESCRIPTION
## Summary

- **hass**: Nomad job with Postgres recorder (no SQLite on NFS), prestart init task writes starter `configuration.yaml` on first deploy, Traefik hostname routing via `hass_hostname` in `nomad/jobs/traefik`
- **matter-server**: python-matter-server WebSocket backend for HA at `matter-server.service.home.consul:5580`
- **traefik**: new `internal-only-direct` middleware that checks `RemoteAddr` rather than `X-Forwarded-For depth:1` — fixes 403 for services accessed directly rather than via Pangolin
- **monitoring**: HTTP probe for hass, TCP probe for matter-server added to `prometheus.yml`
- **CSI volumes**: `hass` and `matter-server` on `rabbitseason-srv-nfs`

## Pre-deploy checklist

- [ ] Create Postgres DB/user and `nomad/jobs/hass` variable — see `nomad/apps/hass/README.md`
- [ ] Add `hass_hostname` to `nomad/jobs/traefik` and redeploy Traefik
- [ ] `nomad volume create` for both new volumes
- [ ] Verify image tags in both job files before running

## Test plan

- [ ] HA onboarding completes and recorder writes to Postgres (no `home-assistant_v2.db` on NFS volume)
- [ ] `https://hass.<hostname>` loads from internal network, returns 403 from external
- [ ] Matter integration connects to `ws://matter-server.service.home.consul:5580/ws`
- [ ] Blackbox probes for both services go green in Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)