### PR TITLE
Add diun: image update notifier watching the Nomad cluster

### DIFF
--- a/monitoring/diun_alerting_rules.yml
+++ b/monitoring/diun_alerting_rules.yml
@@ -1,0 +1,29 @@
+groups:
+- name: diun
+  rules:
+
+  # Diun has no allocation in "running". Catches scheduling failures (image
+  # pull errors, no eligible nodes) as well as the job being stopped; the
+  # absent() arm fires if the job is purged/GC'd and the series disappears
+  # entirely. Crash-loops are covered by the generic NomadTaskFlapping alert.
+  #
+  # Diun exposes no Prometheus metrics of its own, so this is liveness only —
+  # whether registry checks are succeeding is not observable until the
+  # nomad-botherer diun webhook intake ships and provides receiver-side
+  # metrics. Warning, not critical: diun is advisory tooling; a missed 6-hour
+  # check cycle costs nothing.
+  - alert: DiunNotRunning
+    expr: |
+      nomad_nomad_job_summary_running{exported_job="diun"} < 1
+        or
+      absent(nomad_nomad_job_summary_running{exported_job="diun"})
+    for: 15m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Diun is not running"
+      description: >
+        The diun job has had no running allocation for 15 minutes. Image
+        update checks are not happening. Check `nomad job status diun` —
+        common causes are image pull failures or a missing
+        nomad/jobs/diun variable blocking the template.

--- a/nomad/acl/diun-policy.hcl
+++ b/nomad/acl/diun-policy.hcl
@@ -1,0 +1,6 @@
+// Allows Diun's Nomad provider to discover images from running Docker tasks.
+// It lists jobs and reads job/allocation details; nothing is submitted or
+// mutated, so list-jobs + read-job is sufficient.
+namespace "default" {
+  capabilities = ["list-jobs", "read-job"]
+}

--- a/nomad/infra/README.md
+++ b/nomad/infra/README.md
@@ -16,6 +16,7 @@ Infrastructure services that apps depend on.
 | `dns` | Consul-aware DNS | BIND9 forwarding `.consul` to local Consul agent |
 | `homelab-webhook` | GitHub webhook receiver | Pulls gitrepo and reloads monitoring services on push to main |
 | `nomad-botherer` | Nomad job drift detector | Compares HCL definitions in repo against live Nomad jobs; webhook-triggered |
+| `diun` | Image update notifier | Watches registries for new tags of images running in the cluster; notifier pending nomad-botherer webhook intake |
 
 ## SSL certificate pipeline
 

--- a/nomad/infra/diun/README.md
+++ b/nomad/infra/diun/README.md
@@ -1,0 +1,52 @@
+# diun
+
+Runs [Diun](https://github.com/crazy-max/diun) (Docker Image Update Notifier),
+which polls container registries for new tags of images the cluster runs and
+keeps a record of what it has seen.
+
+Uses Diun's **Nomad provider** with `watchByDefault: true`: every running
+Docker-driver task in the cluster is watched, no per-job opt-in meta needed.
+Checks run every 6 hours.
+
+## Notifications
+
+**None configured yet — deliberately.** The plan (see
+`docs/proposals/diun-integration.md` in the nomad-botherer repo) is for Diun
+to POST a webhook to nomad-botherer, which records available image updates
+and serves ready-to-apply HCL patches. nomad-botherer 0.3.1 does not yet
+implement that intake, so for now found updates are only visible in Diun's
+logs:
+
+```bash
+nomad alloc logs -job diun diun
+```
+
+Diun notifies each new tag **once** and remembers it in its state db
+(`/local/diun.db`, ephemeral task disk). When the webhook notifier is added
+later, the db being lost on reschedule is harmless — everything is
+re-notified once and the receiver deduplicates.
+
+## Nomad variables
+
+Reads from `nomad/jobs/diun`. Create before deploying:
+
+```bash
+nomad var put nomad/jobs/diun nomad_token=<acl-token>
+```
+
+| Key           | Required | Description                                              |
+|---------------|----------|----------------------------------------------------------|
+| `nomad_token` | yes      | Nomad ACL token — see `nomad/acl/diun-policy.hcl`        |
+
+Create the policy and token:
+
+```bash
+nomad acl policy apply -description "Diun read access" diun nomad/acl/diun-policy.hcl
+nomad acl token create -name=diun -policy=diun -type=client
+```
+
+## Deployment
+
+```bash
+nomad job run nomad/infra/diun/diun.hcl
+```

--- a/nomad/infra/diun/README.md
+++ b/nomad/infra/diun/README.md
@@ -45,6 +45,20 @@ nomad acl policy apply -description "Diun read access" diun nomad/acl/diun-polic
 nomad acl token create -name=diun -policy=diun -type=client
 ```
 
+## Monitoring
+
+Diun exposes no Prometheus metrics, so monitoring is Nomad-level:
+
+- `DiunNotRunning` (`monitoring/diun_alerting_rules.yml`) — warns when the
+  job has no running allocation (or the job disappears entirely) for 15
+  minutes.
+- Crash-loops and resource pressure are covered by the generic
+  `NomadTaskFlapping` / `nomad-resources` alerts.
+
+Whether registry checks are actually succeeding is not observable until the
+nomad-botherer webhook intake ships and provides receiver-side metrics
+(`nomad_botherer_diun_webhooks_received_total` etc., per the proposal).
+
 ## Deployment
 
 ```bash

--- a/nomad/infra/diun/diun.hcl
+++ b/nomad/infra/diun/diun.hcl
@@ -1,0 +1,46 @@
+job "diun" {
+  datacenters = ["home"]
+  type        = "service"
+
+  meta {
+    gitops_managed = "true"
+  }
+
+  group "diun" {
+
+    task "diun" {
+      driver = "docker"
+
+      config {
+        image = "ghcr.io/crazy-max/diun:4.33.0"
+        args  = ["serve", "--config", "/secrets/diun.yml"]
+      }
+
+      // Config contains the Nomad ACL token, so it lives in secrets/.
+      template {
+        destination = "secrets/diun.yml"
+        data        = <<EOF
+db:
+  path: /local/diun.db
+
+watch:
+  workers: 4
+  schedule: "0 */6 * * *"
+  jitter: 30s
+  firstCheckNotif: false
+
+providers:
+  nomad:
+    address: http://nomad.service.home.consul:4646
+    secretID: {{ with nomadVar "nomad/jobs/diun" }}{{ .nomad_token }}{{ end }}
+    watchByDefault: true
+EOF
+      }
+
+      resources {
+        cpu    = 100
+        memory = 128
+      }
+    }
+  }
+}


### PR DESCRIPTION
Deploys [Diun](https://github.com/crazy-max/diun) 4.33.0 as `nomad/infra/diun`, using its **Nomad provider** with `watchByDefault: true` — every running Docker-driver task's image is watched for new registry tags, checked every 6 hours.

**No notifier is configured yet, deliberately.** The plan is for Diun to webhook into nomad-botherer per `docs/proposals/diun-integration.md` in that repo, but nomad-botherer 0.3.1 doesn't implement the intake yet. Until then, found updates show up in diun's logs. Diun's seen-state db is on ephemeral task disk, which the proposal calls out as fine: a lost db re-notifies everything once and the eventual receiver deduplicates.

Also adds `nomad/acl/diun-policy.hcl` (list-jobs + read-job only) for the provider token.

**Pre-deploy steps** (manual, per repo convention):
```bash
nomad acl policy apply -description "Diun read access" diun nomad/acl/diun-policy.hcl
nomad acl token create -name=diun -policy=diun -type=client
nomad var put nomad/jobs/diun nomad_token=<token from above>
nomad job run nomad/infra/diun/diun.hcl
```

`nomad job validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)