### PR TITLE
diun: tag recommendations script + watchRepo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,11 @@ bash scripts/pg-connect.sh
 bash scripts/check-monitoring-configs.sh
 ```
 
+**Check pinned image tags against updates diun has seen:**
+```bash
+bash scripts/check-image-updates.sh
+```
+
 **Reload Prometheus/Blackbox config (no restart needed):**
 ```bash
 bash scripts/reload_prometheus.sh

--- a/nomad/infra/diun/README.md
+++ b/nomad/infra/diun/README.md
@@ -6,7 +6,23 @@ keeps a record of what it has seen.
 
 Uses Diun's **Nomad provider** with `watchByDefault: true`: every running
 Docker-driver task in the cluster is watched, no per-job opt-in meta needed.
-Checks run every 6 hours.
+Checks run every 6 hours. `defaults.watchRepo: true` makes diun watch the 10
+highest semver tags of each repo (not just the pinned tag), so it knows about
+newer releases.
+
+## Checking for recommended updates
+
+```bash
+bash scripts/check-image-updates.sh
+```
+
+Compares every image tag pinned in `nomad/` HCL against the tags diun has
+seen (queried via `nomad alloc exec` + diun's gRPC CLI) and prints one line
+per image: `UPDATE` (newer tag available), `OK`, `MUTABLE` (latest/nightly
+style tags, digest-tracked only), `UNWATCHED` (no diun record — job not
+running, or no watch cycle since the alloc started), or `SKIP` (image built
+from HCL interpolation). The state db is on ephemeral task disk, so after a
+reschedule expect UNWATCHED until the next watch cycle.
 
 ## Notifications
 

--- a/nomad/infra/diun/diun.hcl
+++ b/nomad/infra/diun/diun.hcl
@@ -29,6 +29,14 @@ watch:
   jitter: 30s
   firstCheckNotif: false
 
+# Without watchRepo diun only tracks digest changes of the pinned tags;
+# it never learns about newer releases. Watch the 10 highest semver tags
+# per repo so scripts/check-image-updates.sh has something to recommend.
+defaults:
+  watchRepo: true
+  maxTags: 10
+  sortTags: semver
+
 providers:
   nomad:
     address: http://nomad.service.home.consul:4646

--- a/scripts/check-image-updates.sh
+++ b/scripts/check-image-updates.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Compare the docker image tags pinned in nomad/ HCL job files against the
+# tags the running diun instance has seen, and print a recommendation for
+# each image reference.
+#
+# Requires: nomad CLI (with cluster access), jq, and the diun job running.
+# diun only learns about newer tags when watchRepo is enabled (see the
+# defaults block in nomad/infra/diun/diun.hcl) and after a watch cycle has
+# run since deploy; until then everything shows as UNWATCHED or OK.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+command -v jq >/dev/null || { echo "error: jq is required" >&2; exit 1; }
+
+# stdin redirected so exec calls inside the read loop don't eat its input
+diun_exec() {
+  nomad alloc exec -t=false -job diun diun "$@" < /dev/null
+}
+
+# Normalise an image name the way diun stores it: registry-qualified, with
+# docker.io/library/ for official images ("postgres", "docker.io/redis").
+normalise() {
+  local name=$1 first=${1%%/*}
+  if [[ $name != */* ]]; then
+    name="docker.io/library/${name}"
+  elif [[ $first != *.* && $first != *:* && $first != localhost ]]; then
+    name="docker.io/${name}"
+  fi
+  if [[ $name == docker.io/* && ${name#docker.io/} != */* ]]; then
+    name="docker.io/library/${name#docker.io/}"
+  fi
+  echo "$name"
+}
+
+echo "Querying diun image database..." >&2
+diun_list=$(diun_exec image list --raw)
+
+declare -A tags_cache
+updates=0
+
+while IFS=$'\t' read -r file image; do
+  # References built from HCL variables/interpolation can't be checked.
+  if [[ $image == *'${'* ]]; then
+    printf 'SKIP      %-55s %s: not a literal image reference\n' "$image" "$file"
+    continue
+  fi
+
+  ref=${image%%@*}   # drop any digest pin
+  tag=latest
+  base=$ref
+  if [[ ${ref##*/} == *:* ]]; then
+    tag=${ref##*:}
+    base=${ref%:*}
+  fi
+  repo=$(normalise "$base")
+
+  if ! jq -e --arg n "$repo" '.images[] | select(.name == $n)' <<<"$diun_list" >/dev/null; then
+    printf 'UNWATCHED %-55s %s: diun has no record (job not running, or no watch cycle yet?)\n' "$repo:$tag" "$file"
+    continue
+  fi
+
+  if [[ $tag == latest || $tag == stable || $tag == nightly || $tag == edge ]]; then
+    printf 'MUTABLE   %-55s %s: mutable tag; diun tracks digest changes only\n' "$repo:$tag" "$file"
+    continue
+  fi
+
+  if [[ ! -v tags_cache[$repo] ]]; then
+    tags_cache[$repo]=$(diun_exec image inspect --image "$repo" --raw \
+      | jq -r '.image.manifests[].tag')
+  fi
+
+  # Candidate tags: same shape as the pinned tag — identical non-version
+  # suffix, so "16" never gets recommended "16-alpine" and "-rc1" tags are
+  # only considered when the pinned tag is itself a prerelease. Sort on the
+  # version with any leading "v" stripped so v-tags and bare tags compare
+  # correctly, and ignore date/CI-build tags (6+ digit first component)
+  # unless the pinned tag is itself one.
+  suffix=$(printf '%s' "$tag" | sed -E 's/^v?[0-9]+(\.[0-9]+)*//')
+  newest=$( { printf '%s\n' "${tags_cache[$repo]}"; echo "$tag"; } \
+    | awk -v suf="$suffix" -v cfg="$tag" '
+        {
+          t = $0; sub(/^v?[0-9]+(\.[0-9]+)*/, "", t)
+          if (t != suf) next
+          key = $0; sub(/^v/, "", key)
+          ckey = cfg; sub(/^v/, "", ckey)
+          if (key ~ /^[0-9]{6}/ && ckey !~ /^[0-9]{6}/) next
+          print key "\t" $0
+        }' \
+    | sort -uV -k1,1 | tail -1 | cut -f2)
+
+  if [[ -z $newest || ${newest#v} == "${tag#v}" ]]; then
+    printf 'OK        %-55s %s: up to date as far as diun knows\n' "$repo:$tag" "$file"
+  else
+    printf 'UPDATE    %-55s %s: bump %s -> %s\n' "$repo:$tag" "$file" "$tag" "$newest"
+    updates=$((updates + 1))
+  fi
+done < <(grep -rHoE 'image[[:space:]]*=[[:space:]]*"[^"]+"' nomad --include='*.hcl' \
+           | sed -E 's/^([^:]+):image[[:space:]]*=[[:space:]]*"([^"]+)"$/\1\t\2/' \
+           | sort -u)
+
+echo >&2
+echo "${updates} update(s) recommended." >&2


### PR DESCRIPTION
Adds `scripts/check-image-updates.sh`: compares every docker image tag pinned in `nomad/` HCL against the tags the running diun instance has seen (queried via `nomad alloc exec -job diun diun image list/inspect --raw`), printing a recommendation per image reference (`UPDATE` / `OK` / `MUTABLE` / `UNWATCHED` / `SKIP`).

Tag comparison is shape-aware: candidates must share the pinned tag's non-version suffix (so `16` is never offered `16-alpine`, and `-rc` tags only match prerelease pins), leading `v` is ignored for ordering, and date/CI-build tags (6+ leading digits) are excluded unless the pin is one.

Also enables `defaults: watchRepo: true, maxTags: 10, sortTags: semver` in diun's config — without watchRepo diun only digest-tracks the pinned tags and never sees newer releases, making recommendations impossible. (Already deployed as job version 1.)

Sample output from the live cluster:
```
UPDATE    ghcr.io/home-assistant/home-assistant:2026.6.1  nomad/apps/hass/hass.hcl: bump 2026.6.1 -> 2026.6.2
UPDATE    docker.io/kutt/kutt:v3.2.3                      nomad/apps/kutt/kutt.hcl: bump v3.2.3 -> v3.2.5
UPDATE    docker.io/miniflux/miniflux:2.2.18              nomad/apps/miniflux/miniflux.hcl: bump 2.2.18 -> 2.3.1
MUTABLE   docker.io/databasus/databasus:latest            nomad/infra/databasus/databasus.hcl: mutable tag; diun tracks digest changes only
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)