### PR TITLE
Add script printing a dev command line for nomad-botherer

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,6 +16,7 @@ Utility scripts for operating the homelab cluster.
 | `dump-nomad-vars.sh` | Dump all Nomad variables to an AES-256-CBC encrypted bash restore script. Use for disaster-recovery backups; restore by decrypting and piping to bash. See below. |
 | `volume-shell.sh` | Start an interactive shell with a Nomad CSI volume mounted at `/<volume-name>`. Useful for inspecting or modifying volume contents directly. |
 | `bother.sh` | CLI wrapper for the nomad-botherer JSON API. Reads the API key from `nomad/jobs/nomad-botherer` and exposes all API endpoints as subcommands (`diffs`, `refresh`, `status`, etc.). Requires `NOMAD_TOKEN`. |
+| `bother-dev-cmdline.sh` | Print a command line for running a local dev build of nomad-botherer outside docker, with the same environment as the deployed version. Renders the env template from the running job spec, including secrets from Nomad variables. Usage: `bash scripts/bother-dev-cmdline.sh [path-to-binary]`. Requires `NOMAD_TOKEN`. Output contains secrets. |
 
 ## Nomad variable backup and restore
 

--- a/scripts/bother-dev-cmdline.sh
+++ b/scripts/bother-dev-cmdline.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# bother-dev-cmdline.sh — print a command line for running a local dev build
+# of nomad-botherer outside docker, with the same environment as the version
+# currently deployed on the cluster.
+#
+# Reads the env template from the running job spec (nomad inspect) and
+# renders its nomadVar lookups, so the output always matches what the
+# deployed task sees — even if the job file changes.
+#
+# WARNING: the output contains secrets (webhook secret, API key, Nomad
+# token). Don't paste it anywhere public.
+#
+# Usage: bother-dev-cmdline.sh [path-to-binary]   (default: ./nomad-botherer)
+#
+# Requires: nomad (with cluster access and NOMAD_TOKEN), jq
+
+set -euo pipefail
+
+BINARY="${1:-./nomad-botherer}"
+JOB="nomad-botherer"
+
+command -v jq >/dev/null || { echo "error: jq is required" >&2; exit 1; }
+
+tmpl=$(nomad inspect "$JOB" \
+  | jq -r --arg t "$JOB" '.Job.TaskGroups[].Tasks[] | select(.Name == $t)
+      | .Templates[] | select(.Envvars == true) | .EmbeddedTmpl')
+[[ -n "$tmpl" ]] || { echo "error: no env template found in running job ${JOB}" >&2; exit 1; }
+
+declare -A var_cache
+cmd="env"
+while IFS= read -r line; do
+  [[ -z "$line" || "$line" == \#* ]] && continue
+  key=${line%%=*}
+  val=${line#*=}
+  # Render {{ with nomadVar "<path>" }}{{ .<item> }}{{ end }} lookups.
+  if [[ $val == *nomadVar* ]]; then
+    var_path=$(sed -n 's/.*nomadVar "\([^"]*\)".*/\1/p' <<<"$val")
+    item=$(sed -n 's/.*{{ \.\([A-Za-z0-9_]*\) }}.*/\1/p' <<<"$val")
+    [[ -n "$var_path" && -n "$item" ]] \
+      || { echo "error: cannot parse template line: $line" >&2; exit 1; }
+    if [[ ! -v var_cache[$var_path] ]]; then
+      var_cache[$var_path]=$(nomad var get -out=json "$var_path") \
+        || { echo "error: cannot read ${var_path} — is NOMAD_TOKEN set?" >&2; exit 1; }
+    fi
+    val=$(jq -re --arg k "$item" '.Items[$k]' <<<"${var_cache[$var_path]}") \
+      || { echo "error: item ${item} not found in ${var_path}" >&2; exit 1; }
+  fi
+  cmd+=" $(printf '%q' "${key}=${val}")"
+done <<<"$tmpl"
+
+echo "$cmd $(printf '%q' "$BINARY")"


### PR DESCRIPTION
Adds `scripts/bother-dev-cmdline.sh`, which prints a copy-pasteable `env KEY=VAL ... <binary>` command line for running a local dev build of nomad-botherer outside docker.

Rather than hardcoding the configuration, it reads the env template from the **running** job spec (`nomad inspect`) and renders the `nomadVar` lookups via `nomad var get`, so the output always matches what the deployed task sees, even after the job file changes. Values are shell-quoted with `printf %q`.

Usage:
```bash
bash scripts/bother-dev-cmdline.sh [path-to-binary]   # default: ./nomad-botherer
```

Requires `nomad` (with `NOMAD_TOKEN`) and `jq`. The output contains secrets (webhook secret, API key, Nomad token).

Tested against the live cluster: produces the full env (`GIT_REPO_URL`, `GIT_BRANCH`, `HCL_DIR`, `LISTEN_ADDR`, `WEBHOOK_PATH`, `NOMAD_ADDR`, `LOG_LEVEL`, plus the three secrets) followed by the binary path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)