### PR TITLE
nomad/acl: expand nomad-botherer policy to cover CSI volume claims

### DIFF
--- a/nomad/acl/README.md
+++ b/nomad/acl/README.md
@@ -7,7 +7,7 @@ Nomad ACL policy definitions.
 | `variable-admin-policy.hcl` | Read/write access to all Nomad variables in all namespaces |
 | `traefik-policy.hcl` | Read access to the default namespace service catalog for Traefik routing |
 | `traefik-vars-policy.hcl` | Read access to `cloud_dns_key` for Traefik's workload identity |
-| `nomad-botherer-policy.hcl` | List, read, and plan jobs in the default namespace (for nomad-botherer drift detection) |
+| `nomad-botherer-policy.hcl` | List, read, plan, and mutate jobs in the default namespace; mount CSI volumes (for nomad-botherer drift detection and job reconciliation) |
 
 ## Prerequisites: workload identity auth method
 
@@ -43,9 +43,7 @@ nomad acl policy apply -description "Traefik service catalog reader" traefik tra
 nomad acl token create -name="traefik" -policy=traefik
 # Store the Secret ID in: nomad var put nomad/jobs/traefik nomad_token=<id>
 
-# nomad-botherer: list, read, and plan jobs for drift detection
-# Note: Nomad has no plan-only capability -- submit-job covers both planning
-# and submitting. nomad-botherer only plans, but the token technically could submit.
+# nomad-botherer: list, read, plan, and mutate jobs; mount CSI volumes for job reconciliation
 nomad acl policy apply -description "nomad-botherer job drift detector" nomad-botherer nomad-botherer-policy.hcl
 nomad acl token create -name="nomad-botherer" -policy=nomad-botherer
 # Store the Secret ID in: nomad var put nomad/jobs/homelab-webhook nomad_token=<id>

--- a/nomad/acl/nomad-botherer-policy.hcl
+++ b/nomad/acl/nomad-botherer-policy.hcl
@@ -1,7 +1,13 @@
-// Allows nomad-botherer to list, read, and plan jobs in the default namespace.
-// Note: Nomad's ACL model does not have a plan-only capability -- submit-job
-// covers both planning and submitting. This token can technically submit jobs,
-// but nomad-botherer only uses the plan API for drift detection.
+// Allows nomad-botherer to list, read, plan, and mutate jobs in the default namespace.
+// csi-list-volume, csi-read-volume, and csi-mount-volume are required when submitting
+// jobs that claim CSI volumes -- Nomad validates and claims volumes at registration time.
 namespace "default" {
-  capabilities = ["list-jobs", "read-job", "submit-job"]
+  capabilities = [
+    "list-jobs",
+    "read-job",
+    "submit-job",
+    "csi-list-volume",
+    "csi-read-volume",
+    "csi-mount-volume",
+  ]
 }


### PR DESCRIPTION
nomad-botherer now mutates and creates jobs, and jobs in this cluster use CSI
volumes. Nomad validates and claims CSI volumes at job registration time, so
submit-job alone returns 403. Add csi-list-volume, csi-read-volume, and
csi-mount-volume to the default namespace capabilities.

https://claude.ai/code/session_01UsFV3ft7LdkwRuREQncPV8