### PR TITLE
nomad-botherer ACL: read on nomad/jobs/* variables + plugin read for CSI

### DIFF
--- a/nomad/acl/README.md
+++ b/nomad/acl/README.md
@@ -7,7 +7,7 @@ Nomad ACL policy definitions.
 | `variable-admin-policy.hcl` | Read/write access to all Nomad variables in all namespaces |
 | `traefik-policy.hcl` | Read access to the default namespace service catalog for Traefik routing |
 | `traefik-vars-policy.hcl` | Read access to `cloud_dns_key` for Traefik's workload identity |
-| `nomad-botherer-policy.hcl` | List, read, plan, and mutate jobs in the default namespace; mount CSI volumes (for nomad-botherer drift detection and job reconciliation) |
+| `nomad-botherer-policy.hcl` | List, read, plan, and mutate jobs in the default namespace; mount CSI volumes; read all `nomad/jobs/*` variables (for nomad-botherer drift detection and job reconciliation) |
 
 ## Prerequisites: workload identity auth method
 

--- a/nomad/acl/README.md
+++ b/nomad/acl/README.md
@@ -7,7 +7,7 @@ Nomad ACL policy definitions.
 | `variable-admin-policy.hcl` | Read/write access to all Nomad variables in all namespaces |
 | `traefik-policy.hcl` | Read access to the default namespace service catalog for Traefik routing |
 | `traefik-vars-policy.hcl` | Read access to `cloud_dns_key` for Traefik's workload identity |
-| `nomad-botherer-policy.hcl` | List, read, plan, and mutate jobs in the default namespace; mount CSI volumes; read all `nomad/jobs/*` variables (for nomad-botherer drift detection and job reconciliation) |
+| `nomad-botherer-policy.hcl` | List, read, plan, and mutate jobs in the default namespace; mount CSI volumes (namespace `csi-mount-volume` + top-level `plugin` read); read all `nomad/jobs/*` variables (for nomad-botherer drift detection and job reconciliation) |
 
 ## Prerequisites: workload identity auth method
 

--- a/nomad/acl/nomad-botherer-policy.hcl
+++ b/nomad/acl/nomad-botherer-policy.hcl
@@ -1,6 +1,13 @@
 // Allows nomad-botherer to list, read, plan, and mutate jobs in the default namespace.
 // csi-list-volume, csi-read-volume, and csi-mount-volume are required when submitting
 // jobs that claim CSI volumes -- Nomad validates and claims volumes at registration time.
+//
+// The variables{} block grants read access to all job-level variables. Nomad
+// enforces an anti-privilege-escalation check at job registration: a token that
+// submits a job whose templates read a Nomad variable (via nomadVar) must itself
+// have read access to that variable path. Without this, submitting any job that
+// reads its nomad/jobs/<jobname> secrets fails with a 403. Since botherer can
+// reconcile any gitops-managed job, it needs read on the whole nomad/jobs/* tree.
 namespace "default" {
   capabilities = [
     "list-jobs",
@@ -10,4 +17,10 @@ namespace "default" {
     "csi-read-volume",
     "csi-mount-volume",
   ]
+
+  variables {
+    path "nomad/jobs/*" {
+      capabilities = ["read"]
+    }
+  }
 }

--- a/nomad/acl/nomad-botherer-policy.hcl
+++ b/nomad/acl/nomad-botherer-policy.hcl
@@ -8,6 +8,14 @@
 // have read access to that variable path. Without this, submitting any job that
 // reads its nomad/jobs/<jobname> secrets fails with a 403. Since botherer can
 // reconcile any gitops-managed job, it needs read on the whole nomad/jobs/* tree.
+//
+// The plugin{} block grants read on the CSI plugin catalog. Registering a job
+// that mounts a CSI volume is gated by AllowCSIMount, which requires BOTH the
+// namespace csi-mount-volume capability AND plugin read -- csi-mount-volume
+// alone is not enough and the submit fails with a 403 (e.g. kutt, which mounts
+// the "kutt" CSI volume). Verified against the live cluster: with csi-mount-volume
+// and the variables grant but no plugin read, register is denied; adding plugin
+// read lets it through.
 namespace "default" {
   capabilities = [
     "list-jobs",
@@ -23,4 +31,8 @@ namespace "default" {
       capabilities = ["read"]
     }
   }
+}
+
+plugin {
+  policy = "read"
 }


### PR DESCRIPTION
## Problem

A test token bound to the `nomad-botherer` policy gets a **403 on `nomad job run`** (observed against `kutt`), even though the policy already has `submit-job`.

## Cause

Nomad enforces an anti-privilege-escalation check at job registration: a token that submits a job whose `template` reads a Nomad variable (via `nomadVar`) must itself have **read access to that variable path**. `kutt` reads `nomad/jobs/kutt` (`DB_PASSWORD`, `JWT_SECRET`), but the botherer policy had no `variables` block — so `submit-job` alone is not sufficient and the submit is denied.

## Fix

Add a `variables {}` block granting `read` on `nomad/jobs/*`. Since botherer can reconcile any gitops-managed job, it needs read on the whole job-level variable tree (read only — it submits jobs, it doesn't write variables). Syntax matches the existing `traefik-vars-policy.hcl`.

## Applying

Re-apply the policy; the existing bound token picks it up live (no token recreation needed):

```bash
nomad acl policy apply -description "nomad-botherer job drift detector" nomad-botherer nomad/acl/nomad-botherer-policy.hcl
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)