### PR TITLE
nomad-botherer ACL policy: add CSI volume capabilities; hass 2026.6.3

### DIFF
--- a/nomad/apps/hass/hass.hcl
+++ b/nomad/apps/hass/hass.hcl
@@ -106,7 +106,7 @@ EOF
       }
 
       config {
-        image        = "ghcr.io/home-assistant/home-assistant:2026.6.1"
+        image        = "ghcr.io/home-assistant/home-assistant:2026.6.3"
         ports        = ["http"]
         network_mode = "host"
       }


### PR DESCRIPTION
## Summary

- Expand nomad-botherer ACL policy to add `csi-list-volume`, `csi-read-volume`, and `csi-mount-volume` capabilities — required now that nomad-botherer creates/updates jobs, since Nomad validates and claims CSI volumes at job registration time
- Upgrade Home Assistant from 2026.6.1 to 2026.6.3

## Test plan

- [ ] Apply updated ACL policy: `nomad acl policy apply -description "nomad-botherer job drift detector and reconciler" nomad-botherer nomad/acl/nomad-botherer-policy.hcl`
- [ ] Verify nomad-botherer no longer gets 403 when mutating jobs with CSI volumes
- [ ] Deploy hass: `nomad job run nomad/apps/hass/hass.hcl`
- [ ] Confirm hass comes up healthy at https://hass.home.andvari.net

https://claude.ai/code/session_01UsFV3ft7LdkwRuREQncPV8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsFV3ft7LdkwRuREQncPV8)_