### PR TITLE
hass: enable image-only gitops update policy

### DIFF
--- a/nomad/apps/hass/hass.hcl
+++ b/nomad/apps/hass/hass.hcl
@@ -2,7 +2,8 @@ job "hass" {
   datacenters = ["home"]
 
   meta {
-    gitops_managed = "true"
+    gitops_managed       = "true"
+    gitops_update_policy = "image-only"
   }
 
   group "hass" {


### PR DESCRIPTION
## Summary

- Adds `gitops_update_policy = "image-only"` to the hass job meta block so nomad-botherer will only update the image tag rather than reconciling the full job spec.

## Test plan

- [ ] Deploy: `nomad job run nomad/apps/hass/hass.hcl`
- [ ] Confirm nomad-botherer only touches the image on subsequent drift detection runs

https://claude.ai/code/session_01UsFV3ft7LdkwRuREQncPV8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsFV3ft7LdkwRuREQncPV8)_