### PR TITLE
nomad client: prefer IPv4 for interface fingerprinting

### DIFF
--- a/ansible/roles/hashicorp/files/client.hcl
+++ b/ansible/roles/hashicorp/files/client.hcl
@@ -1,3 +1,11 @@
 client {
   enabled = true
+
+  # Prefer IPv4 when fingerprinting interface addresses. Without this, a node
+  # with an IPv6 (e.g. a ULA fdxx::/8) address on its default interface can
+  # register host-network services in Consul with that IPv6 address, which
+  # IPv4-only consumers (newt, Traefik backends, scrape targets) can't reach.
+  # Added in Nomad 1.9.0. Requires a nomad restart to take effect; services
+  # re-register with the IPv4 address on their next registration.
+  preferred_address_family = "ipv4"
 }


### PR DESCRIPTION
## Problem

After upgrading kutt it rescheduled onto `duckseason` and registered its Consul service with an **IPv6 ULA** address (`fdbe:6a8a:11e1:5d19:2e0:4cff:fef4:1f28`) instead of IPv4. `kutt.service.home.consul` now returns only an AAAA record (no A), so IPv4-only consumers — newt (which was complaining), Traefik backends, scrape targets — can't reach it.

`duckseason` has an IPv6 ULA on its default interface; Nomad's host-network fingerprinter picked it. The node's Consul *node* address is still IPv4 (192.168.100.253) — only the host-network *service* registration went IPv6.

## Fix

Set `client.preferred_address_family = "ipv4"` in `client.hcl` (Nomad 1.9.0+; we run 1.11.3). The fingerprinter then prefers the node's IPv4 address, so host-network services register with IPv4.

This is the Nomad-native answer to "can IPv6 be disabled for Nomad" — it doesn't touch OS-level IPv6, it just stops Nomad from advertising the v6 address.

## Rollout

`client.hcl` is deployed by the `hashicorp` role and notifies a nomad restart. After running the playbook:

1. Nomad restarts on each node and re-fingerprints (IPv4-preferred).
2. Existing host-network services re-register with IPv4 on their next registration — kutt may need a `nomad job run nomad/apps/kutt/kutt.hcl` (or alloc reschedule) to re-register and clear the stale AAAA record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)