### PR TITLE
Bump nomad-botherer to 0.7.0

### DIFF
--- a/nomad/infra/nomad-botherer/nomad-botherer.hcl
+++ b/nomad/infra/nomad-botherer/nomad-botherer.hcl
@@ -16,7 +16,7 @@ job "nomad-botherer" {
       driver = "docker"
 
       config {
-        image = "ghcr.io/gerrowadat/nomad-botherer:0.5.0"
+        image = "ghcr.io/gerrowadat/nomad-botherer:0.7.0"
         ports = ["nomad-botherer"]
       }
 


### PR DESCRIPTION
Upgrades the `nomad-botherer` image from `0.5.0` to `0.7.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)