### PR TITLE
databasus: gitops image-only updates, pin to 3.42.0

### DIFF
--- a/nomad/infra/databasus/databasus.hcl
+++ b/nomad/infra/databasus/databasus.hcl
@@ -4,6 +4,7 @@ job "databasus" {
 
   meta {
     gitops_managed = "true"
+    gitops_update_policy = "image-only"
   }
 
   group "databasus" {
@@ -25,7 +26,7 @@ job "databasus" {
       driver = "docker"
 
       config {
-        image = "docker.io/databasus/databasus:latest"
+        image = "docker.io/databasus/databasus:3.42.0"
         ports = ["http"]
       }
 


### PR DESCRIPTION
Sets up nomad-botherer gitops management for databasus, scoped to image updates only, and pins the image version.

- Add `gitops_update_policy = "image-only"` to the `meta` block (alongside the existing `gitops_managed = "true"`) so botherer reconciles **image drift only**, matching the pattern used by hass and miniflux.
- Pin the image from `:latest` to `:3.42.0` (image-only reconciliation needs a concrete tag to track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)