### PR TITLE
databasus: correct image tag to v3.42.0

### DIFF
--- a/nomad/infra/databasus/databasus.hcl
+++ b/nomad/infra/databasus/databasus.hcl
@@ -26,7 +26,7 @@ job "databasus" {
       driver = "docker"
 
       config {
-        image = "docker.io/databasus/databasus:3.42.0"
+        image = "docker.io/databasus/databasus:v3.42.0"
         ports = ["http"]
       }
 


### PR DESCRIPTION
Follow-up to #162 — the databasus image tag is prefixed with `v`. Fixes `3.42.0` -> `v3.42.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)