### PR TITLE
newt 1.13.0, z2m 2.12.0; image-only gitops for both

### DIFF
--- a/nomad/infra/newt/newt.hcl
+++ b/nomad/infra/newt/newt.hcl
@@ -2,6 +2,7 @@ job "newt" {
   datacenters = ["home"]
   meta {
     gitops_managed = "true"
+    gitops_update_policy = "image-only"
   }
   group "newt_servers" {
     count = 1
@@ -15,7 +16,7 @@ job "newt" {
       }
       driver = "docker"
       config {
-        image = "fosrl/newt:1.10.4"
+        image = "fosrl/newt:1.13.0"
         labels {
           group = "newt"
         }

--- a/nomad/infra/z2m/z2m.hcl
+++ b/nomad/infra/z2m/z2m.hcl
@@ -3,6 +3,7 @@ job "z2m" {
   datacenters = ["home"]
   meta {
     gitops_managed = "true"
+    gitops_update_policy = "image-only"
   }
   group "z2m_servers" {
 
@@ -28,7 +29,7 @@ job "z2m" {
       # 'nobody' keeps the process unprivileged otherwise.
       user = "nobody:dialout"
       config {
-        image = "koenkk/zigbee2mqtt:2.9.2"
+        image = "koenkk/zigbee2mqtt:2.12.0"
         volumes = [
           # udev is needed so the container can detect the Conbee stick's device path.
           "/run/udev:/run/udev:ro",


### PR DESCRIPTION
Bumps two infra images and scopes their nomad-botherer reconciliation to image updates only.

- **newt**: `1.10.4` -> `1.13.0`
- **z2m** (zigbee2mqtt): `2.9.2` -> `2.12.0`
- Both already had `gitops_managed = "true"`; added `gitops_update_policy = "image-only"` to each so botherer reconciles image drift only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)