### PR TITLE
Bump mysql to 9.7.0 (LTS)

### DIFF
--- a/nomad/infra/mysql/README.md
+++ b/nomad/infra/mysql/README.md
@@ -1,6 +1,6 @@
 # mysql
 
-MySQL 8.4 database server. Used by apps that require MySQL (e.g. Zigbee2MQTT).
+MySQL 9.7 LTS database server. Used by apps that require MySQL (e.g. birdnet).
 
 Reachable at `mysql.service.home.consul:3306` from within the cluster.
 

--- a/nomad/infra/mysql/mysql.hcl
+++ b/nomad/infra/mysql/mysql.hcl
@@ -25,7 +25,7 @@ job "mysql" {
 
       driver = "docker"
       config {
-        image = "mysql:8.4.8"
+        image = "mysql:9.7.0"
         ports = ["mysql"]
         labels {
           group = "mysql"


### PR DESCRIPTION
Upgrades MySQL `8.4.8` -> `9.7.0`.

## Why this is a safe jump
- **9.7 is the new LTS line** (released 2026-04-21). 8.4 LTS -> 9.7 LTS is the supported in-place upgrade path, so this stays off the short-lived Innovation track.
- **Auth checked on the live instance:** `mysql_native_password` was removed in 9.0, but **no account uses it** — all (root, birdnet, databasus, internal) are on `caching_sha2_password`. Nothing breaks on auth.
- README corrected: the stale "e.g. Zigbee2MQTT" consumer is replaced with **birdnet**, the actual MySQL client (z2m uses MQTT, not MySQL).

## Operational notes for deploy (not blocking this PR)
- The datadir upgrade on first boot of 9.7 is **one-way** — no in-place downgrade to 8.4. **Take and verify a MySQL backup (databasus) before `nomad job run`.**
- `count = 1`, but the CSI volume is `multi-node-multi-writer`; ensure the old alloc is fully stopped before the new one mounts the datadir so two servers never touch it at once.
- birdnet loses its DB connection during the restart window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)