### PR TITLE
fix(monitoring): use job= not exported_job= in DiunNotRunning alert

### DIFF
--- a/monitoring/diun_alerting_rules.yml
+++ b/monitoring/diun_alerting_rules.yml
@@ -14,9 +14,9 @@ groups:
   # check cycle costs nothing.
   - alert: DiunNotRunning
     expr: |
-      nomad_nomad_job_summary_running{exported_job="diun"} < 1
+      nomad_nomad_job_summary_running{job="diun"} < 1
         or
-      absent(nomad_nomad_job_summary_running{exported_job="diun"})
+      absent(nomad_nomad_job_summary_running{job="diun"})
     for: 15m
     labels:
       severity: warning


### PR DESCRIPTION
The Nomad scrape job uses honor_labels=true, which preserves Nomad's own
job="diun" label verbatim. exported_job is only set when honor_labels is
false (Prometheus renames a conflicting job label to exported_job).

With exported_job="diun", the series selector never matched anything, so
the absent() arm fired continuously even while diun was running fine.

https://claude.ai/code/session_0133zPaBi9t6xLQkkdJLMQzg