### PR TITLE
fix(monitoring): repair OtelCollectorDown alert (label + condition)

### DIFF
--- a/monitoring/log_collection_alerting_rules.yml
+++ b/monitoring/log_collection_alerting_rules.yml
@@ -51,14 +51,25 @@
     "labels":
       "severity": "warning"
 
-  # One or more otel-collector tasks has a failed allocation. Since this is a
-  # system job, any failure means a node has lost log collection entirely.
+  # A new otel-collector allocation has failed recently. This is a system job,
+  # so a failing alloc means a node has lost log collection.
+  #
+  # The job name lives in the `job` label, not `exported_job`: the nomad scrape
+  # uses honor_labels (see prometheus.yml), so the metric's own job="otel-collector"
+  # label is preserved. The previous exported_job selector matched nothing, so
+  # this alert never fired.
+  #
+  # We alert on increase() over a window, not on the raw failed gauge:
+  # nomad_nomad_job_summary_failed is a cumulative count of allocs ever failed,
+  # so it is non-zero on a perfectly healthy job (historical failures) and
+  # `> 0` would fire permanently. increase(...[15m]) > 0 fires only on a *new*
+  # failure and self-resolves once the window passes with no further failures.
   - "alert": "OtelCollectorDown"
     "annotations":
-      "summary": "otel-collector has a failed allocation"
-      "description": "The otel-collector system job has {{ $value }} failed allocation(s). At least one cluster node is not collecting logs."
+      "summary": "otel-collector allocation failed"
+      "description": "The otel-collector system job has had {{ $value }} new failed allocation(s) in the last 15m. At least one cluster node may have lost log collection."
     "expr": |
-      nomad_nomad_job_summary_failed{exported_job="otel-collector"} > 0
+      increase(nomad_nomad_job_summary_failed{job="otel-collector"}[15m]) > 0
     "for": "5m"
     "labels":
       "severity": "critical"


### PR DESCRIPTION
## Problem
`OtelCollectorDown` is a **dead alert** — it can never fire, so a real log-collection outage would go unnoticed. Two bugs:

1. **Wrong label.** It selects `exported_job="otel-collector"`, but the nomad scrape uses `honor_labels` (prometheus.yml), so the job name is in the **`job`** label. The selector matches nothing. (Same root cause as the spurious `DiunNotRunning` alert — see PR #166.)
2. **Wrong condition.** `nomad_nomad_job_summary_failed > 0` reads a **cumulative** counter of allocs that have *ever* failed — currently **13** on a perfectly healthy 4/4 job (0 new failures in 24h). A label-only fix would immediately fire a spurious *critical*.

## Fix
- `exported_job` → `job`.
- Condition → `increase(nomad_nomad_job_summary_failed{job="otel-collector"}[15m]) > 0`, which fires only on a **new** failure and self-resolves once the window passes. Matches the original "a task failed" intent without alarming on history.
- Comment updated to explain both choices.

## Verification
- `scripts/check-monitoring-configs.sh` passes.
- Against live Prometheus, the new expression evaluates **empty** (no new failures in 15m), so it won't fire on the 13 historical ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)