### PR TITLE
homelab-webhook: make reloads resilient + unbuffered logs

### DIFF
--- a/nomad/infra/homelab-webhook/homelab-webhook.hcl
+++ b/nomad/infra/homelab-webhook/homelab-webhook.hcl
@@ -35,6 +35,14 @@ job "homelab-webhook" {
         destination = "/gitrepo"
       }
 
+      // Ensure stdout is never block-buffered, so reload/pull logs reach
+      // `nomad alloc logs` immediately even if a future webhook.py drops the
+      // explicit flush. Without this, log output can sit unflushed and a
+      // failed reload looks like silence.
+      env {
+        PYTHONUNBUFFERED = "1"
+      }
+
       template {
         destination = "secrets/env"
         env         = true

--- a/nomad/infra/homelab-webhook/webhook.py
+++ b/nomad/infra/homelab-webhook/webhook.py
@@ -7,6 +7,7 @@ import http.server
 import json
 import os
 import subprocess
+import time
 import urllib.request
 
 
@@ -86,17 +87,43 @@ def touches_grafana_config(payload):
     return bool(changed)
 
 
-def reload_services():
-    for url in RELOAD_TARGETS:
-        log(f"Sending POST /-/reload to {url}")
+def post_with_retries(url, headers=None, attempts=3, timeout=5, backoff=2):
+    """POST to url with retries. Raises RuntimeError if all attempts fail.
+
+    A reload POST that fails silently leaves the running service on stale
+    config until the next monitoring push (this is how a fixed alert rule sat
+    undeployed for a day). Retrying rides out transient blips, and the caller
+    attempts every target rather than aborting on the first failure.
+    """
+    last = None
+    for n in range(1, attempts + 1):
         req = urllib.request.Request(url, method="POST", data=b"")
+        for key, value in (headers or {}).items():
+            req.add_header(key, value)
         try:
-            with urllib.request.urlopen(req, timeout=10) as resp:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
                 if resp.status not in (200, 204):
                     raise RuntimeError(f"HTTP {resp.status}")
-                log(f"  -> OK (HTTP {resp.status})")
+                log(f"  -> OK (HTTP {resp.status})" + ("" if n == 1 else f" on attempt {n}"))
+                return
         except Exception as e:
-            raise RuntimeError(f"Reload failed for {url}: {e}")
+            last = e
+            log(f"  -> attempt {n}/{attempts} FAILED for {url}: {e}")
+            if n < attempts:
+                time.sleep(backoff)
+    raise RuntimeError(f"{url}: {last}")
+
+
+def reload_services():
+    failures = []
+    for url in RELOAD_TARGETS:
+        log(f"Sending POST /-/reload to {url}")
+        try:
+            post_with_retries(url)
+        except Exception as e:
+            failures.append(str(e))
+    if failures:
+        raise RuntimeError("Reload failed for: " + "; ".join(failures))
 
 
 def reload_grafana():
@@ -105,17 +132,16 @@ def reload_grafana():
     credentials = base64.b64encode(
         f"{GRAFANA_ADMIN_USER}:{GRAFANA_ADMIN_PASSWORD}".encode()
     ).decode()
+    headers = {"Authorization": f"Basic {credentials}"}
+    failures = []
     for url in GRAFANA_RELOAD_TARGETS:
         log(f"Sending POST to {url}")
-        req = urllib.request.Request(url, method="POST", data=b"")
-        req.add_header("Authorization", f"Basic {credentials}")
         try:
-            with urllib.request.urlopen(req, timeout=10) as resp:
-                if resp.status not in (200, 204):
-                    raise RuntimeError(f"HTTP {resp.status}")
-                log(f"  -> OK (HTTP {resp.status})")
+            post_with_retries(url, headers=headers)
         except Exception as e:
-            raise RuntimeError(f"Grafana reload failed for {url}: {e}")
+            failures.append(str(e))
+    if failures:
+        raise RuntimeError("Grafana reload failed for: " + "; ".join(failures))
 
 
 class WebhookHandler(http.server.BaseHTTPRequestHandler):


### PR DESCRIPTION
Hardens the webhook reload pipeline — the reason a fixed alert rule (`DiunNotRunning`) sat undeployed on the running Prometheus for ~a day despite being correct on the gitrepo volume.

## Changes
- **Attempt every reload target, with retries.** `reload_services()` previously `raise`d on the *first* target failure (line 99), so a transient blip on prometheus would skip alertmanager + blackbox and leave the reload undone with no retry. Now each target is POSTed with **3 attempts / 2s backoff**, all targets are attempted, and failures are aggregated. Same for `reload_grafana()`. A genuine failure still surfaces as a 500 so the GitHub delivery shows failed (and can be redelivered).
- **`PYTHONUNBUFFERED=1`** in the job env so stdout is never block-buffered — reload/pull logs reach `nomad alloc logs` immediately. (The running webhook alloc had *empty* logs, which made the failed reload look like silence. `log()` flushes in the current repo, but the live container runs a 2-month-old copy that predates it; this guarantees it regardless.)

## Note on rollout
`webhook.py` is `cp`'d from the gitrepo volume at **container start**, so these changes only take effect after a redeploy:
```
nomad job run nomad/infra/homelab-webhook/homelab-webhook.hcl
```

## Verification
- `python3 -m py_compile webhook.py` ✓
- `nomad job validate homelab-webhook.hcl` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)