### PR TITLE
databasus: bump memory 256->512 MiB to stop nightly backup OOMs

### DIFF
--- a/nomad/infra/databasus/databasus.hcl
+++ b/nomad/infra/databasus/databasus.hcl
@@ -54,7 +54,11 @@ job "databasus" {
 
       resources {
         cpu    = 100
-        memory = 256
+        # databasus bundles an embedded Postgres (metadata store) alongside the
+        # Go app, and the scheduled backup run spikes on top of both. At 256 the
+        # task pinned its limit during the nightly backup and was OOM-killed
+        # (exit 137), failing the backup; idle sits ~100 MiB. 512 gives headroom.
+        memory = 512
       }
     }
   }


### PR DESCRIPTION
## Symptom
A run of databasus **backup failures**. Root cause: the task is **OOM-killed** (Exit Code 137 / "OOM Killed") during its scheduled backup, then restart-loops — `nomad job status databasus` shows 9 failed allocs, with Task Events full of `Terminated  Exit Code: 137, Exit Message: "OOM Killed"` clustered at **~00:00** each night.

## Why
The databasus task runs an **embedded PostgreSQL** (its own metadata store — visible in stderr: checkpoints, "database system is ready to accept connections") *plus* the Go web/backup app in a single task under one 256 MiB limit. Idle it sits ~100 MiB, but the nightly backup run spikes on top of the embedded PG + app and crosses 256 MiB. Prometheus confirms peak usage pinned at **~257 MiB = the limit** (`max_over_time(nomad_client_allocs_memory_usage{task="databasus"}[7d])`), i.e. capped by the OOM.

## Fix
`memory = 256` → `512` MiB — comfortable headroom over the ~100 MiB idle baseline and the backup spike. (cpu unchanged.)

## After merge
```
nomad job run nomad/infra/databasus/databasus.hcl
```
Then watch `nomad_client_allocs_memory_usage{task="databasus"}` across the next nightly run; if it still approaches 512 we bump again, but small config/metadata DBs shouldn't need more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)