### PR TITLE
databasus: enable full gitops policy

### DIFF
--- a/nomad/infra/databasus/databasus.hcl
+++ b/nomad/infra/databasus/databasus.hcl
@@ -4,7 +4,7 @@ job "databasus" {
 
   meta {
     gitops_managed = "true"
-    gitops_update_policy = "image-only"
+    gitops_update_policy = "full"
   }
 
   group "databasus" {


### PR DESCRIPTION
Changes databasus's `gitops_update_policy` from `image-only` to `full`, so nomad-botherer reconciles drift across the **entire job spec** (resources, env, templates, …), not just the image tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)