### PR TITLE
nomad-botherer: authenticate to Nomad via workload identity

### DIFF
--- a/nomad/acl/README.md
+++ b/nomad/acl/README.md
@@ -43,10 +43,14 @@ nomad acl policy apply -description "Traefik service catalog reader" traefik tra
 nomad acl token create -name="traefik" -policy=traefik
 # Store the Secret ID in: nomad var put nomad/jobs/traefik nomad_token=<id>
 
-# nomad-botherer: list, read, plan, and mutate jobs; mount CSI volumes for job reconciliation
-nomad acl policy apply -description "nomad-botherer job drift detector" nomad-botherer nomad-botherer-policy.hcl
-nomad acl token create -name="nomad-botherer" -policy=nomad-botherer
-# Store the Secret ID in: nomad var put nomad/jobs/homelab-webhook nomad_token=<id>
+# nomad-botherer: list, read, plan, and mutate jobs; mount CSI volumes; read variables.
+# Uses workload identity (no static token): the policy is ASSOCIATED WITH THE JOB
+# via -job, so the nomad-botherer task's default identity gets these capabilities.
+# The job's `identity { file = true }` block materialises the token at
+# ${NOMAD_SECRETS_DIR}/nomad_token, which nomad-botherer auto-detects.
+nomad acl policy apply -namespace default -job nomad-botherer \
+  -description "nomad-botherer job drift detector" \
+  nomad-botherer nomad-botherer-policy.hcl
 ```
 
 See `backpack.sh` for the bootstrap sequence that runs these on a fresh cluster.

--- a/nomad/infra/nomad-botherer/README.md
+++ b/nomad/infra/nomad-botherer/README.md
@@ -27,14 +27,22 @@ Reads from `nomad/jobs/nomad-botherer`. Create or update before deploying:
 
 ```bash
 nomad var put nomad/jobs/nomad-botherer \
-  github_webhook_secret=<secret> \
-  nomad_token=<optional-acl-token>
+  github_webhook_secret=<secret>
 ```
 
 | Key                     | Required | Description                                                      |
 |-------------------------|----------|------------------------------------------------------------------|
 | `github_webhook_secret` | yes      | HMAC secret configured in the GitHub webhook settings            |
-| `nomad_token`           | no       | Nomad ACL token — see `nomad/acl/nomad-botherer-policy.hcl`     |
+
+## Nomad access (workload identity)
+
+This job authenticates to the Nomad API with its **default workload identity**,
+not a static token. The task's `identity { file = true }` block makes Nomad
+write a short-lived, auto-renewed ACL token to `${NOMAD_SECRETS_DIR}/nomad_token`,
+which nomad-botherer (>= 0.9.0) auto-detects. Capabilities come from the
+`nomad-botherer` policy **associated with this job** — see
+`nomad/acl/README.md`. No `nomad_token` variable is needed; if one lingers from
+the old setup it is unused and the static token can be deleted.
 
 ---
 

--- a/nomad/infra/nomad-botherer/nomad-botherer.hcl
+++ b/nomad/infra/nomad-botherer/nomad-botherer.hcl
@@ -15,6 +15,19 @@ job "nomad-botherer" {
     task "nomad-botherer" {
       driver = "docker"
 
+      // Access Nomad via this task's default workload identity. Nomad writes a
+      // short-lived, auto-renewed ACL token to ${NOMAD_SECRETS_DIR}/nomad_token,
+      // which nomad-botherer (>= 0.9.0) auto-detects when no token is otherwise
+      // configured -- so no static token is needed. Permissions come from the
+      // nomad-botherer policy associated with this job:
+      //   nomad acl policy apply -namespace default -job nomad-botherer \
+      //     nomad-botherer nomad/acl/nomad-botherer-policy.hcl
+      // Do NOT set env = true: the env token is captured once at task start and
+      // would expire; file mode is renewed in place.
+      identity {
+        file = true
+      }
+
       config {
         image = "ghcr.io/gerrowadat/nomad-botherer:0.9.0"
         ports = ["nomad-botherer"]
@@ -33,7 +46,6 @@ NOMAD_ADDR=http://nomad.service.home.consul:4646
 LOG_LEVEL=debug
 WEBHOOK_SECRET={{ with nomadVar "nomad/jobs/nomad-botherer" }}{{ .github_webhook_secret }}{{ end }}
 API_KEY={{ with nomadVar "nomad/jobs/nomad-botherer" }}{{ .github_webhook_secret }}{{ end }}
-NOMAD_TOKEN={{ with nomadVar "nomad/jobs/nomad-botherer" }}{{ .nomad_token }}{{ end }}
 EOF
       }
 


### PR DESCRIPTION
Switches nomad-botherer from a static `NOMAD_TOKEN` (read from the `nomad/jobs/nomad-botherer` variable) to the task's **default Nomad workload identity** (supported by nomad-botherer >= 0.9.0).

## Changes
- **Job:** add `identity { file = true }` to the task. Nomad writes a short-lived, auto-renewed ACL token to `${NOMAD_SECRETS_DIR}/nomad_token`, which nomad-botherer auto-detects when no token is otherwise configured. Remove the `NOMAD_TOKEN=…` template line. (`env = true` is deliberately **not** used — the env token is captured once at task start and would expire; file mode is renewed in place.)
- **Docs:** `nomad/acl/README.md` now applies the policy **associated with the job** (`nomad acl policy apply -job nomad-botherer …`) instead of creating a static token; `nomad/infra/nomad-botherer/README.md` documents the workload-identity model and drops the `nomad_token` variable key.

The policy file itself is unchanged — same capabilities (list/read/submit jobs, CSI mount + plugin read, `nomad/jobs/*` variable read); only how it's granted changes (job-associated identity vs. a token).

`nomad job validate` passes.

## Rollout
See the PR comment / chat — needs the policy re-applied with `-job` **before** redeploying, then cleanup of the old token/variable key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)