### PR TITLE
Revert nomad-botherer workload identity (broke Nomad API auth)

### DIFF
--- a/nomad/acl/README.md
+++ b/nomad/acl/README.md
@@ -43,14 +43,10 @@ nomad acl policy apply -description "Traefik service catalog reader" traefik tra
 nomad acl token create -name="traefik" -policy=traefik
 # Store the Secret ID in: nomad var put nomad/jobs/traefik nomad_token=<id>
 
-# nomad-botherer: list, read, plan, and mutate jobs; mount CSI volumes; read variables.
-# Uses workload identity (no static token): the policy is ASSOCIATED WITH THE JOB
-# via -job, so the nomad-botherer task's default identity gets these capabilities.
-# The job's `identity { file = true }` block materialises the token at
-# ${NOMAD_SECRETS_DIR}/nomad_token, which nomad-botherer auto-detects.
-nomad acl policy apply -namespace default -job nomad-botherer \
-  -description "nomad-botherer job drift detector" \
-  nomad-botherer nomad-botherer-policy.hcl
+# nomad-botherer: list, read, plan, and mutate jobs; mount CSI volumes for job reconciliation
+nomad acl policy apply -description "nomad-botherer job drift detector" nomad-botherer nomad-botherer-policy.hcl
+nomad acl token create -name="nomad-botherer" -policy=nomad-botherer
+# Store the Secret ID in: nomad var put nomad/jobs/homelab-webhook nomad_token=<id>
 ```
 
 See `backpack.sh` for the bootstrap sequence that runs these on a fresh cluster.

--- a/nomad/infra/nomad-botherer/README.md
+++ b/nomad/infra/nomad-botherer/README.md
@@ -27,22 +27,14 @@ Reads from `nomad/jobs/nomad-botherer`. Create or update before deploying:
 
 ```bash
 nomad var put nomad/jobs/nomad-botherer \
-  github_webhook_secret=<secret>
+  github_webhook_secret=<secret> \
+  nomad_token=<optional-acl-token>
 ```
 
 | Key                     | Required | Description                                                      |
 |-------------------------|----------|------------------------------------------------------------------|
 | `github_webhook_secret` | yes      | HMAC secret configured in the GitHub webhook settings            |
-
-## Nomad access (workload identity)
-
-This job authenticates to the Nomad API with its **default workload identity**,
-not a static token. The task's `identity { file = true }` block makes Nomad
-write a short-lived, auto-renewed ACL token to `${NOMAD_SECRETS_DIR}/nomad_token`,
-which nomad-botherer (>= 0.9.0) auto-detects. Capabilities come from the
-`nomad-botherer` policy **associated with this job** — see
-`nomad/acl/README.md`. No `nomad_token` variable is needed; if one lingers from
-the old setup it is unused and the static token can be deleted.
+| `nomad_token`           | no       | Nomad ACL token — see `nomad/acl/nomad-botherer-policy.hcl`     |
 
 ---
 

--- a/nomad/infra/nomad-botherer/nomad-botherer.hcl
+++ b/nomad/infra/nomad-botherer/nomad-botherer.hcl
@@ -15,19 +15,6 @@ job "nomad-botherer" {
     task "nomad-botherer" {
       driver = "docker"
 
-      // Access Nomad via this task's default workload identity. Nomad writes a
-      // short-lived, auto-renewed ACL token to ${NOMAD_SECRETS_DIR}/nomad_token,
-      // which nomad-botherer (>= 0.9.0) auto-detects when no token is otherwise
-      // configured -- so no static token is needed. Permissions come from the
-      // nomad-botherer policy associated with this job:
-      //   nomad acl policy apply -namespace default -job nomad-botherer \
-      //     nomad-botherer nomad/acl/nomad-botherer-policy.hcl
-      // Do NOT set env = true: the env token is captured once at task start and
-      // would expire; file mode is renewed in place.
-      identity {
-        file = true
-      }
-
       config {
         image = "ghcr.io/gerrowadat/nomad-botherer:0.9.0"
         ports = ["nomad-botherer"]
@@ -46,6 +33,7 @@ NOMAD_ADDR=http://nomad.service.home.consul:4646
 LOG_LEVEL=debug
 WEBHOOK_SECRET={{ with nomadVar "nomad/jobs/nomad-botherer" }}{{ .github_webhook_secret }}{{ end }}
 API_KEY={{ with nomadVar "nomad/jobs/nomad-botherer" }}{{ .github_webhook_secret }}{{ end }}
+NOMAD_TOKEN={{ with nomadVar "nomad/jobs/nomad-botherer" }}{{ .nomad_token }}{{ end }}
 EOF
       }
 


### PR DESCRIPTION
Reverts #176.

## Why
After deploying the workload-identity change, **every** `Jobs.Plan()` failed with:
```
500 (rpc error: acl token lookup failed: index error: UUID must be 36 characters)
```
botherer could not plan any job, so drift detection/reconciliation was fully down.

## Root cause
The `identity { file = true }` block writes the task's **default** workload-identity **JWT** (verified: 882 chars, 2 dots, `eyJhbGci…`) to `${NOMAD_SECRETS_DIR}/nomad_token`, and botherer presents it to the Nomad API. But Nomad routed it to the **Secret-ID (UUID) lookup** and rejected it — i.e. the default workload identity is **not accepted as a Nomad API token** on this cluster (Nomad 1.11.3). The minimal `identity { file = true }` + `acl policy apply -job` recipe from the botherer docs was not sufficient here; the API-access path needs more (almost certainly an explicit audience on the identity, and/or server-side default-identity config — TBD).

## Status
- Running job already reverted live to v11 (static token) via `nomad job revert`; `healthz` is `ok`, `diff_count: 0`, plans succeed, no UUID errors.
- The static token (`nomad/jobs/nomad-botherer` `nomad_token`) was never cleaned up, so it still works.
- This PR brings **git back in line with the working running state** so a redeploy from main can't re-break botherer.

Workload identity can be re-attempted in a fresh PR once the correct Nomad-side config (audience etc.) is nailed down and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)