### PR TITLE
nomad-botherer: workload identity via ACL login exchange (0.9.1)

### DIFF
--- a/nomad/acl/README.md
+++ b/nomad/acl/README.md
@@ -43,10 +43,19 @@ nomad acl policy apply -description "Traefik service catalog reader" traefik tra
 nomad acl token create -name="traefik" -policy=traefik
 # Store the Secret ID in: nomad var put nomad/jobs/traefik nomad_token=<id>
 
-# nomad-botherer: list, read, plan, and mutate jobs; mount CSI volumes for job reconciliation
+# nomad-botherer: list, read, plan, and mutate jobs; mount CSI volumes; read variables.
+# Uses workload identity via the ACL login exchange (nomad-botherer >= 0.9.1) --
+# no static token. The job has a named identity `nomad-api` (aud "nomad.io"); on
+# login the binding rule below grants it the nomad-botherer policy. A raw WI JWT
+# cannot be used directly (Nomad's Job.Plan rejects it), hence the exchange.
 nomad acl policy apply -description "nomad-botherer job drift detector" nomad-botherer nomad-botherer-policy.hcl
-nomad acl token create -name="nomad-botherer" -policy=nomad-botherer
-# Store the Secret ID in: nomad var put nomad/jobs/homelab-webhook nomad_token=<id>
+nomad acl binding-rule create \
+  -auth-method nomad-workloads -bind-type policy \
+  -bind-name nomad-botherer \
+  -selector 'value.nomad_job_id == "nomad-botherer"'
 ```
+
+The `nomad-workloads` JWT auth method (see the top of this file) must exist, and
+its `bound_audiences` (`nomad.io`) must match the job's `identity` block `aud`.
 
 See `backpack.sh` for the bootstrap sequence that runs these on a fresh cluster.

--- a/nomad/infra/nomad-botherer/README.md
+++ b/nomad/infra/nomad-botherer/README.md
@@ -27,14 +27,22 @@ Reads from `nomad/jobs/nomad-botherer`. Create or update before deploying:
 
 ```bash
 nomad var put nomad/jobs/nomad-botherer \
-  github_webhook_secret=<secret> \
-  nomad_token=<optional-acl-token>
+  github_webhook_secret=<secret>
 ```
 
 | Key                     | Required | Description                                                      |
 |-------------------------|----------|------------------------------------------------------------------|
 | `github_webhook_secret` | yes      | HMAC secret configured in the GitHub webhook settings            |
-| `nomad_token`           | no       | Nomad ACL token — see `nomad/acl/nomad-botherer-policy.hcl`     |
+
+## Nomad access (workload identity)
+
+Authenticates to the Nomad API with the task's **workload identity**, exchanged
+for a real ACL token — no static token. A raw WI JWT can't be used directly
+(Nomad's `Job.Plan` rejects it), so nomad-botherer (>= 0.9.1) exchanges the
+named identity's JWT for an ACL token via `POST /v1/acl/login` and refreshes it
+before expiry (`NOMAD_LOGIN_AUTH_METHOD` / `NOMAD_LOGIN_JWT_FILE` in the job).
+Capabilities come from the `nomad-botherer` policy, granted on login by a
+binding rule — see `nomad/acl/README.md`. No `nomad_token` variable is needed.
 
 ---
 

--- a/nomad/infra/nomad-botherer/nomad-botherer.hcl
+++ b/nomad/infra/nomad-botherer/nomad-botherer.hcl
@@ -15,8 +15,25 @@ job "nomad-botherer" {
     task "nomad-botherer" {
       driver = "docker"
 
+      // Authenticate to Nomad via workload identity + ACL login exchange.
+      // A raw WI JWT is rejected by Nomad's Job.Plan RPC (500 "UUID must be 36
+      // characters"), so nomad-botherer (>= 0.9.1) exchanges this named
+      // identity's JWT for a real ACL token via POST /v1/acl/login (see the
+      // NOMAD_LOGIN_* env below) and re-exchanges it before expiry. The named
+      // identity's aud must match the nomad-workloads auth method's
+      // bound_audiences (nomad.io); the default identity's aud does not, which
+      // is why a dedicated named identity is used. Capabilities come from the
+      // nomad-botherer policy, granted on login by the binding rule
+      //   value.nomad_job_id == "nomad-botherer"
+      // (see nomad/acl/README.md). No static token to manage or rotate.
+      identity {
+        name = "nomad-api"
+        aud  = ["nomad.io"]
+        file = true
+      }
+
       config {
-        image = "ghcr.io/gerrowadat/nomad-botherer:0.9.0"
+        image = "ghcr.io/gerrowadat/nomad-botherer:0.9.1"
         ports = ["nomad-botherer"]
       }
 
@@ -33,7 +50,8 @@ NOMAD_ADDR=http://nomad.service.home.consul:4646
 LOG_LEVEL=debug
 WEBHOOK_SECRET={{ with nomadVar "nomad/jobs/nomad-botherer" }}{{ .github_webhook_secret }}{{ end }}
 API_KEY={{ with nomadVar "nomad/jobs/nomad-botherer" }}{{ .github_webhook_secret }}{{ end }}
-NOMAD_TOKEN={{ with nomadVar "nomad/jobs/nomad-botherer" }}{{ .nomad_token }}{{ end }}
+NOMAD_LOGIN_AUTH_METHOD=nomad-workloads
+NOMAD_LOGIN_JWT_FILE=/secrets/nomad_nomad-api.jwt
 EOF
       }
 


### PR DESCRIPTION
Retry of the workload-identity switch (previous attempt #176 reverted in #177), using **nomad-botherer 0.9.1**, which fixes it the way we determined in [issue #74](https://github.com/gerrowadat/nomad-botherer/issues/74).

## Why the previous attempt failed
A raw workload-identity **JWT** authenticates read RPCs but is **rejected by Nomad's `Job.Plan` RPC** (`500 UUID must be 36 characters`), and botherer plans on every drift check. Proven empirically (read → 200, plan → 500 over both TCP and the Task API socket).

## The fix (0.9.1)
botherer now **exchanges** the identity JWT for a real ACL token via `POST /v1/acl/login` and refreshes it before expiry.

## Changes
- image `0.9.0` → `0.9.1`
- **named identity** `nomad-api` with `aud = ["nomad.io"]` — matches the `nomad-workloads` auth method's `bound_audiences`; the *default* identity's aud does **not** match, which is the key gotcha.
- `NOMAD_LOGIN_AUTH_METHOD=nomad-workloads`, `NOMAD_LOGIN_JWT_FILE=/secrets/nomad_nomad-api.jwt`
- drop the static `NOMAD_TOKEN`
- docs: ACL README documents the **binding rule** (job → policy on login); job README documents the login model and drops the `nomad_token` variable.

## Cluster prerequisite (already applied)
Binding rule created on `nomad-workloads`: `value.nomad_job_id == "nomad-botherer"` → `nomad-botherer` policy. The auth method and policy already existed.

Verified live before merge (see PR discussion): login succeeds and plans run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)