### PR TITLE
nomad-botherer: add ttl to WI identity so the JWT is renewed

### DIFF
--- a/nomad/infra/nomad-botherer/nomad-botherer.hcl
+++ b/nomad/infra/nomad-botherer/nomad-botherer.hcl
@@ -30,6 +30,15 @@ job "nomad-botherer" {
         name = "nomad-api"
         aud  = ["nomad.io"]
         file = true
+        // ttl is required: without it Nomad issues a non-expiring JWT and never
+        // rewrites the file, so once the exchanged ACL token expires (~30m) the
+        // re-login presents a stale JWT the auth method rejects and botherer
+        // loses access. With ttl set, Nomad issues an expiring JWT and renews
+        // the file (~2/3 through the ttl) so a valid JWT is always present.
+        // change_mode = noop: renewals must not restart the task (botherer
+        // re-reads the file itself).
+        ttl         = "1h"
+        change_mode = "noop"
       }
 
       config {


### PR DESCRIPTION
Follow-up fix to #178. The 0.9.1 workload-identity login rollout **logged in initially but broke after ~30 min**.

## Root cause
The named identity had **no `ttl`**, so Nomad issued a **non-expiring JWT** (no `exp` claim) and **never rewrote the file**. Once the first exchanged ACL token (30 min, the auth method's `max_token_ttl`) expired, botherer re-logged in with the now-stale JWT and the auth method rejected it (`401 … token is expired`) → loss of access, every plan failing with `ACL token expired`. (The `healthz` "ok" was misleading — same false-healthy pattern as before.)

## Fix
`ttl = "1h"` on the identity (+ `change_mode = "noop"` so renewals don't restart the task; botherer re-reads the file itself).

## Verified empirically
Throwaway job with `ttl = "3m"`:
- **Without ttl:** JWT has **no `exp`**, file `iat` frozen at task start → not renewed.
- **With ttl:** JWT gains `exp` (=iat+ttl), and Nomad **rewrote the file at ~t+60s** (iat advanced, exp reset) — i.e. renews at ~2/3 of the ttl, always keeping a valid JWT present.

## Rollout note
Running job was reverted to the static token (v15) to restore service while diagnosing. After merge I'll deploy this and **soak-test past one 30-min token cycle** to confirm the re-login actually rotates before declaring it done — no premature "verified" this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)